### PR TITLE
feat: add tenancy REST endpoints

### DIFF
--- a/app/Http/Controllers/Tenancy/EmpresaController.php
+++ b/app/Http/Controllers/Tenancy/EmpresaController.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace App\Http\Controllers\Tenancy;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+
+class EmpresaController extends Controller
+{
+    public function index(Request $request)
+    {
+        $page = max((int) $request->query('page', 1), 1);
+        $per = (int) $request->query('per_page', 20);
+        $per = $per > 100 ? 100 : $per;
+        $off = ($page - 1) * $per;
+
+        $q = $request->query('q');
+        $activo = $request->query('activo');
+
+        $params = [
+            'q' => $q,
+            'activo' => $activo,
+            'per' => $per,
+            'off' => $off,
+        ];
+
+        $sql = "SELECT e.*
+FROM empresas e
+WHERE e.deleted_at IS NULL
+  AND (:q IS NULL OR (
+        e.ruc LIKE CONCAT('%', :q, '%') OR
+        e.razon_social LIKE CONCAT('%', :q, '%') OR
+        e.nombre_comercial LIKE CONCAT('%', :q, '%')
+      ))
+  AND (:activo IS NULL OR e.activo = :activo)
+ORDER BY e.id DESC
+LIMIT :per OFFSET :off";
+
+        $rows = DB::select($sql, $params);
+
+        $countSql = "SELECT COUNT(1) AS total
+FROM empresas e
+WHERE e.deleted_at IS NULL
+  AND (:q IS NULL OR (
+        e.ruc LIKE CONCAT('%', :q, '%') OR
+        e.razon_social LIKE CONCAT('%', :q, '%') OR
+        e.nombre_comercial LIKE CONCAT('%', :q, '%')
+      ))
+  AND (:activo IS NULL OR e.activo = :activo)";
+
+        $total = DB::selectOne($countSql, $params)->total ?? 0;
+
+        return [
+            'data' => array_map(fn($r) => (array) $r, $rows),
+            'pagination' => [
+                'page' => $page,
+                'per_page' => $per,
+                'total' => (int) $total,
+            ],
+        ];
+    }
+
+    public function store(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'razon_social' => ['required'],
+            'ruc' => ['required', 'size:13'],
+            'nombre_comercial' => ['nullable'],
+            'email' => ['nullable', 'email'],
+            'telefono' => ['nullable'],
+            'direccion' => ['nullable'],
+            'pais' => ['nullable'],
+            'provincia' => ['nullable'],
+            'ciudad' => ['nullable'],
+            'activo' => ['boolean'],
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => $validator->errors()->toArray(),
+            ], 422);
+        }
+        $data = $validator->validated();
+        $data['activo'] = $data['activo'] ?? 1;
+
+        $exists = DB::selectOne(
+            "SELECT id FROM empresas WHERE ruc = :ruc AND deleted_at IS NULL",
+            ['ruc' => $data['ruc']]
+        );
+        if ($exists) {
+            return response()->json([
+                'error' => 'Conflict',
+                'message' => 'RUC ya registrado',
+            ], 409);
+        }
+
+        return DB::transaction(function () use ($data) {
+            DB::insert(
+                "INSERT INTO empresas
+(razon_social, nombre_comercial, ruc, email, telefono, direccion, pais, provincia, ciudad, activo, created_at, updated_at)
+VALUES
+(:razon_social, :nombre_comercial, :ruc, :email, :telefono, :direccion, :pais, :provincia, :ciudad, :activo, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                $data
+            );
+            $empresa = DB::selectOne("SELECT * FROM empresas WHERE id = LAST_INSERT_ID()");
+            return ['data' => (array) $empresa];
+        });
+    }
+
+    public function show($id)
+    {
+        $row = DB::selectOne(
+            "SELECT e.*
+FROM empresas e
+WHERE e.id = :id AND e.deleted_at IS NULL
+LIMIT 1",
+            ['id' => $id]
+        );
+        if (!$row) {
+            return response()->json([
+                'error' => 'NotFound',
+                'message' => 'Recurso no encontrado',
+            ], 404);
+        }
+        return ['data' => (array) $row];
+    }
+
+    public function update(Request $request, $id)
+    {
+        $validator = Validator::make($request->all(), [
+            'razon_social' => ['required'],
+            'ruc' => ['required', 'size:13'],
+            'nombre_comercial' => ['nullable'],
+            'email' => ['nullable', 'email'],
+            'telefono' => ['nullable'],
+            'direccion' => ['nullable'],
+            'pais' => ['nullable'],
+            'provincia' => ['nullable'],
+            'ciudad' => ['nullable'],
+            'activo' => ['boolean'],
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => $validator->errors()->toArray(),
+            ], 422);
+        }
+        $data = $validator->validated();
+        $data['activo'] = $data['activo'] ?? 1;
+        $data['id'] = $id;
+
+        $exists = DB::selectOne(
+            "SELECT id FROM empresas WHERE ruc = :ruc AND id <> :id AND deleted_at IS NULL",
+            ['ruc' => $data['ruc'], 'id' => $id]
+        );
+        if ($exists) {
+            return response()->json([
+                'error' => 'Conflict',
+                'message' => 'RUC ya registrado',
+            ], 409);
+        }
+
+        return DB::transaction(function () use ($data, $id) {
+            $affected = DB::update(
+                "UPDATE empresas
+SET razon_social = :razon_social,
+    nombre_comercial = :nombre_comercial,
+    ruc = :ruc,
+    email = :email,
+    telefono = :telefono,
+    direccion = :direccion,
+    pais = :pais,
+    provincia = :provincia,
+    ciudad = :ciudad,
+    activo = :activo,
+    updated_at = CURRENT_TIMESTAMP
+WHERE id = :id AND deleted_at IS NULL",
+                $data
+            );
+            if (!$affected) {
+                return response()->json([
+                    'error' => 'NotFound',
+                    'message' => 'Recurso no encontrado',
+                ], 404);
+            }
+            $empresa = DB::selectOne("SELECT * FROM empresas WHERE id = :id", ['id' => $id]);
+            return ['data' => (array) $empresa];
+        });
+    }
+
+    public function destroy($id)
+    {
+        $affected = DB::update(
+            "UPDATE empresas
+SET deleted_at = CURRENT_TIMESTAMP,
+    updated_at = CURRENT_TIMESTAMP
+WHERE id = :id AND deleted_at IS NULL",
+            ['id' => $id]
+        );
+        if (!$affected) {
+            return response()->json([
+                'error' => 'NotFound',
+                'message' => 'Recurso no encontrado',
+            ], 404);
+        }
+        return response()->json(null, 204);
+    }
+}

--- a/app/Http/Controllers/Tenancy/LocalController.php
+++ b/app/Http/Controllers/Tenancy/LocalController.php
@@ -1,0 +1,233 @@
+<?php
+
+namespace App\Http\Controllers\Tenancy;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+
+class LocalController extends Controller
+{
+    public function index(Request $request)
+    {
+        $page = max((int) $request->query('page', 1), 1);
+        $per = (int) $request->query('per_page', 20);
+        $per = $per > 100 ? 100 : $per;
+        $off = ($page - 1) * $per;
+
+        $empresa_id = $request->query('empresa_id');
+        $q = $request->query('q');
+        $activo = $request->query('activo');
+
+        $params = [
+            'empresa_id' => $empresa_id,
+            'q' => $q,
+            'activo' => $activo,
+            'per' => $per,
+            'off' => $off,
+        ];
+
+        $sql = "SELECT l.*
+FROM locales l
+JOIN empresas e ON e.id = l.empresa_id AND e.deleted_at IS NULL
+WHERE l.deleted_at IS NULL
+  AND (:empresa_id IS NULL OR l.empresa_id = :empresa_id)
+  AND (:q IS NULL OR (
+        l.nombre LIKE CONCAT('%', :q, '%') OR
+        l.codigo_establecimiento LIKE CONCAT('%', :q, '%') OR
+        l.codigo_punto_emision LIKE CONCAT('%', :q, '%')
+      ))
+  AND (:activo IS NULL OR l.activo = :activo)
+ORDER BY l.id DESC
+LIMIT :per OFFSET :off";
+
+        $rows = DB::select($sql, $params);
+
+        $countSql = "SELECT COUNT(1) AS total
+FROM locales l
+JOIN empresas e ON e.id = l.empresa_id AND e.deleted_at IS NULL
+WHERE l.deleted_at IS NULL
+  AND (:empresa_id IS NULL OR l.empresa_id = :empresa_id)
+  AND (:q IS NULL OR (
+        l.nombre LIKE CONCAT('%', :q, '%') OR
+        l.codigo_establecimiento LIKE CONCAT('%', :q, '%') OR
+        l.codigo_punto_emision LIKE CONCAT('%', :q, '%')
+      ))
+  AND (:activo IS NULL OR l.activo = :activo)";
+
+        $total = DB::selectOne($countSql, $params)->total ?? 0;
+
+        return [
+            'data' => array_map(fn($r) => (array) $r, $rows),
+            'pagination' => [
+                'page' => $page,
+                'per_page' => $per,
+                'total' => (int) $total,
+            ],
+        ];
+    }
+
+    public function store(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'empresa_id' => ['required', 'integer'],
+            'nombre' => ['required'],
+            'direccion' => ['nullable'],
+            'telefono' => ['nullable'],
+            'codigo_establecimiento' => ['required'],
+            'codigo_punto_emision' => ['required'],
+            'secuencial_factura' => ['required', 'integer'],
+            'secuencial_nc' => ['required', 'integer'],
+            'secuencial_retencion' => ['required', 'integer'],
+            'activo' => ['boolean'],
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => $validator->errors()->toArray(),
+            ], 422);
+        }
+        $data = $validator->validated();
+        $data['activo'] = $data['activo'] ?? 1;
+
+        $empresa = DB::selectOne("SELECT id FROM empresas WHERE id = :id AND deleted_at IS NULL", ['id' => $data['empresa_id']]);
+        if (!$empresa) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => ['empresa_id' => ['empresa inexistente']],
+            ], 422);
+        }
+
+        $exists = DB::selectOne(
+            "SELECT id FROM locales WHERE empresa_id = :empresa_id AND codigo_establecimiento = :codigo_establecimiento AND codigo_punto_emision = :codigo_punto_emision AND deleted_at IS NULL",
+            [
+                'empresa_id' => $data['empresa_id'],
+                'codigo_establecimiento' => $data['codigo_establecimiento'],
+                'codigo_punto_emision' => $data['codigo_punto_emision'],
+            ]
+        );
+        if ($exists) {
+            return response()->json([
+                'error' => 'Conflict',
+                'message' => 'Combinación SRI ya registrada',
+            ], 409);
+        }
+
+        return DB::transaction(function () use ($data) {
+            DB::insert(
+                "INSERT INTO locales
+(empresa_id, nombre, direccion, telefono, codigo_establecimiento, codigo_punto_emision,
+ secuencial_factura, secuencial_nc, secuencial_retencion, activo, created_at, updated_at)
+VALUES
+(:empresa_id, :nombre, :direccion, :telefono, :codigo_establecimiento, :codigo_punto_emision,
+ :secuencial_factura, :secuencial_nc, :secuencial_retencion, :activo, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                $data
+            );
+            $local = DB::selectOne("SELECT * FROM locales WHERE id = LAST_INSERT_ID()");
+            return ['data' => (array) $local];
+        });
+    }
+
+    public function show($id)
+    {
+        $row = DB::selectOne(
+            "SELECT l.*
+FROM locales l
+JOIN empresas e ON e.id = l.empresa_id AND e.deleted_at IS NULL
+WHERE l.id = :id AND l.deleted_at IS NULL
+LIMIT 1",
+            ['id' => $id]
+        );
+        if (!$row) {
+            return response()->json([
+                'error' => 'NotFound',
+                'message' => 'Recurso no encontrado',
+            ], 404);
+        }
+        return ['data' => (array) $row];
+    }
+
+    public function update(Request $request, $id)
+    {
+        $validator = Validator::make($request->all(), [
+            'nombre' => ['required'],
+            'direccion' => ['nullable'],
+            'telefono' => ['nullable'],
+            'codigo_establecimiento' => ['required'],
+            'codigo_punto_emision' => ['required'],
+            'secuencial_factura' => ['required', 'integer'],
+            'secuencial_nc' => ['required', 'integer'],
+            'secuencial_retencion' => ['required', 'integer'],
+            'activo' => ['boolean'],
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => $validator->errors()->toArray(),
+            ], 422);
+        }
+        $data = $validator->validated();
+        $data['activo'] = $data['activo'] ?? 1;
+        $data['id'] = $id;
+
+        $exists = DB::selectOne(
+            "SELECT id FROM locales WHERE empresa_id = (SELECT empresa_id FROM locales WHERE id = :id) AND codigo_establecimiento = :codigo_establecimiento AND codigo_punto_emision = :codigo_punto_emision AND id <> :id AND deleted_at IS NULL",
+            [
+                'codigo_establecimiento' => $data['codigo_establecimiento'],
+                'codigo_punto_emision' => $data['codigo_punto_emision'],
+                'id' => $id,
+            ]
+        );
+        if ($exists) {
+            return response()->json([
+                'error' => 'Conflict',
+                'message' => 'Combinación SRI ya registrada',
+            ], 409);
+        }
+
+        return DB::transaction(function () use ($data, $id) {
+            $affected = DB::update(
+                "UPDATE locales
+SET nombre = :nombre,
+    direccion = :direccion,
+    telefono = :telefono,
+    codigo_establecimiento = :codigo_establecimiento,
+    codigo_punto_emision  = :codigo_punto_emision,
+    secuencial_factura    = :secuencial_factura,
+    secuencial_nc         = :secuencial_nc,
+    secuencial_retencion  = :secuencial_retencion,
+    activo = :activo,
+    updated_at = CURRENT_TIMESTAMP
+WHERE id = :id AND deleted_at IS NULL",
+                $data
+            );
+            if (!$affected) {
+                return response()->json([
+                    'error' => 'NotFound',
+                    'message' => 'Recurso no encontrado',
+                ], 404);
+            }
+            $local = DB::selectOne("SELECT * FROM locales WHERE id = :id", ['id' => $id]);
+            return ['data' => (array) $local];
+        });
+    }
+
+    public function destroy($id)
+    {
+        $affected = DB::update(
+            "UPDATE locales
+SET deleted_at = CURRENT_TIMESTAMP,
+    updated_at = CURRENT_TIMESTAMP
+WHERE id = :id AND deleted_at IS NULL",
+            ['id' => $id]
+        );
+        if (!$affected) {
+            return response()->json([
+                'error' => 'NotFound',
+                'message' => 'Recurso no encontrado',
+            ], 404);
+        }
+        return response()->json(null, 204);
+    }
+}

--- a/app/Http/Controllers/Tenancy/SubscriptionStatusController.php
+++ b/app/Http/Controllers/Tenancy/SubscriptionStatusController.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Http\Controllers\Tenancy;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+
+class SubscriptionStatusController extends Controller
+{
+    public function __invoke(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'local_id' => ['required', 'integer'],
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => $validator->errors()->toArray(),
+            ], 422);
+        }
+        $local_id = $validator->validated()['local_id'];
+
+        $row = DB::selectOne(
+            "SELECT
+  CASE
+    WHEN e.activo = 1
+     AND l.activo = 1
+     AND EXISTS (
+       SELECT 1
+       FROM suscripciones s
+       WHERE s.empresa_id = e.id
+         AND s.estado = 'ACTIVA'
+         AND s.fecha_inicio <= CURRENT_DATE()
+         AND (s.fecha_fin IS NULL OR s.fecha_fin >= CURRENT_DATE())
+     )
+     AND EXISTS (
+       SELECT 1
+       FROM suscripciones_locales sl
+       JOIN suscripciones s2 ON s2.id = sl.suscripcion_id
+       WHERE sl.local_id = l.id
+         AND sl.estado = 'ACTIVA'
+         AND sl.fecha_inicio <= CURRENT_DATE()
+         AND (sl.fecha_fin IS NULL OR sl.fecha_fin >= CURRENT_DATE())
+         AND s2.estado = 'ACTIVA'
+         AND s2.fecha_inicio <= CURRENT_DATE()
+         AND (s2.fecha_fin IS NULL OR s2.fecha_fin >= CURRENT_DATE())
+     )
+    THEN 1 ELSE 0
+  END AS vigente,
+  e.id AS empresa_id,
+  l.id AS local_id
+FROM locales l
+JOIN empresas e ON e.id = l.empresa_id
+WHERE l.id = :local_id
+  AND e.deleted_at IS NULL
+  AND l.deleted_at IS NULL
+LIMIT 1",
+            ['local_id' => $local_id]
+        );
+
+        if (!$row) {
+            return response()->json([
+                'error' => 'NotFound',
+                'message' => 'Recurso no encontrado',
+            ], 404);
+        }
+
+        return ['data' => (array) $row];
+    }
+}

--- a/app/Http/Controllers/Tenancy/SuscripcionController.php
+++ b/app/Http/Controllers/Tenancy/SuscripcionController.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace App\Http\Controllers\Tenancy;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+
+class SuscripcionController extends Controller
+{
+    public function index(Request $request)
+    {
+        $page = max((int) $request->query('page', 1), 1);
+        $per = (int) $request->query('per_page', 20);
+        $per = $per > 100 ? 100 : $per;
+        $off = ($page - 1) * $per;
+
+        $empresa_id = $request->query('empresa_id');
+        $estado = $request->query('estado');
+        $vigentes = $request->query('vigentes');
+
+        $params = [
+            'empresa_id' => $empresa_id,
+            'estado' => $estado,
+            'vigentes' => $vigentes,
+            'per' => $per,
+            'off' => $off,
+        ];
+
+        $sql = "SELECT s.*
+FROM suscripciones s
+JOIN empresas e ON e.id = s.empresa_id AND e.deleted_at IS NULL
+WHERE (:empresa_id IS NULL OR s.empresa_id = :empresa_id)
+  AND (:estado IS NULL OR s.estado = :estado)
+  AND (:vigentes IS NULL OR (
+        s.estado = 'ACTIVA' AND
+        s.fecha_inicio <= CURRENT_DATE() AND
+        (s.fecha_fin IS NULL OR s.fecha_fin >= CURRENT_DATE())
+      ))
+ORDER BY s.id DESC
+LIMIT :per OFFSET :off";
+
+        $rows = DB::select($sql, $params);
+
+        $countSql = "SELECT COUNT(1) AS total
+FROM suscripciones s
+JOIN empresas e ON e.id = s.empresa_id AND e.deleted_at IS NULL
+WHERE (:empresa_id IS NULL OR s.empresa_id = :empresa_id)
+  AND (:estado IS NULL OR s.estado = :estado)
+  AND (:vigentes IS NULL OR (
+        s.estado = 'ACTIVA' AND
+        s.fecha_inicio <= CURRENT_DATE() AND
+        (s.fecha_fin IS NULL OR s.fecha_fin >= CURRENT_DATE())
+      ))";
+
+        $total = DB::selectOne($countSql, $params)->total ?? 0;
+
+        return [
+            'data' => array_map(fn($r) => (array) $r, $rows),
+            'pagination' => [
+                'page' => $page,
+                'per_page' => $per,
+                'total' => (int) $total,
+            ],
+        ];
+    }
+
+    public function store(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'empresa_id' => ['required', 'integer'],
+            'plan_id' => ['required', 'integer'],
+            'fecha_inicio' => ['required', 'date'],
+            'fecha_fin' => ['nullable', 'date', 'after_or_equal:fecha_inicio'],
+            'estado' => ['required'],
+            'ultimo_pago' => ['nullable', 'date'],
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => $validator->errors()->toArray(),
+            ], 422);
+        }
+        $data = $validator->validated();
+
+        $empresa = DB::selectOne("SELECT id FROM empresas WHERE id = :id AND deleted_at IS NULL", ['id' => $data['empresa_id']]);
+        if (!$empresa) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => ['empresa_id' => ['empresa inexistente']],
+            ], 422);
+        }
+
+        return DB::transaction(function () use ($data) {
+            DB::insert(
+                "INSERT INTO suscripciones
+(empresa_id, plan_id, fecha_inicio, fecha_fin, estado, ultimo_pago, created_at, updated_at)
+VALUES
+(:empresa_id, :plan_id, :fecha_inicio, :fecha_fin, :estado, :ultimo_pago, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                $data
+            );
+            $row = DB::selectOne("SELECT * FROM suscripciones WHERE id = LAST_INSERT_ID()");
+            return ['data' => (array) $row];
+        });
+    }
+
+    public function show($id)
+    {
+        $row = DB::selectOne(
+            "SELECT s.*
+FROM suscripciones s
+JOIN empresas e ON e.id = s.empresa_id AND e.deleted_at IS NULL
+WHERE s.id = :id
+LIMIT 1",
+            ['id' => $id]
+        );
+        if (!$row) {
+            return response()->json([
+                'error' => 'NotFound',
+                'message' => 'Recurso no encontrado',
+            ], 404);
+        }
+        return ['data' => (array) $row];
+    }
+
+    public function update(Request $request, $id)
+    {
+        $validator = Validator::make($request->all(), [
+            'plan_id' => ['required', 'integer'],
+            'fecha_inicio' => ['required', 'date'],
+            'fecha_fin' => ['nullable', 'date', 'after_or_equal:fecha_inicio'],
+            'estado' => ['required'],
+            'ultimo_pago' => ['nullable', 'date'],
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => $validator->errors()->toArray(),
+            ], 422);
+        }
+        $data = $validator->validated();
+        $data['id'] = $id;
+
+        return DB::transaction(function () use ($data, $id) {
+            $affected = DB::update(
+                "UPDATE suscripciones
+SET plan_id = :plan_id,
+    fecha_inicio = :fecha_inicio,
+    fecha_fin = :fecha_fin,
+    estado = :estado,
+    ultimo_pago = :ultimo_pago,
+    updated_at = CURRENT_TIMESTAMP
+WHERE id = :id",
+                $data
+            );
+            if (!$affected) {
+                return response()->json([
+                    'error' => 'NotFound',
+                    'message' => 'Recurso no encontrado',
+                ], 404);
+            }
+            $row = DB::selectOne("SELECT * FROM suscripciones WHERE id = :id", ['id' => $id]);
+            return ['data' => (array) $row];
+        });
+    }
+}

--- a/app/Http/Controllers/Tenancy/SuscripcionLocalController.php
+++ b/app/Http/Controllers/Tenancy/SuscripcionLocalController.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace App\Http\Controllers\Tenancy;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+
+class SuscripcionLocalController extends Controller
+{
+    public function index(Request $request)
+    {
+        $page = max((int) $request->query('page', 1), 1);
+        $per = (int) $request->query('per_page', 20);
+        $per = $per > 100 ? 100 : $per;
+        $off = ($page - 1) * $per;
+
+        $local_id = $request->query('local_id');
+        $estado = $request->query('estado');
+        $vigentes = $request->query('vigentes');
+
+        $params = [
+            'local_id' => $local_id,
+            'estado' => $estado,
+            'vigentes' => $vigentes,
+            'per' => $per,
+            'off' => $off,
+        ];
+
+        $sql = "SELECT sl.*
+FROM suscripciones_locales sl
+JOIN suscripciones s ON s.id = sl.suscripcion_id
+JOIN locales l ON l.id = sl.local_id AND l.deleted_at IS NULL
+JOIN empresas e ON e.id = l.empresa_id AND e.deleted_at IS NULL
+WHERE (:local_id IS NULL OR sl.local_id = :local_id)
+  AND (:estado IS NULL OR sl.estado = :estado)
+  AND (:vigentes IS NULL OR (
+        sl.estado = 'ACTIVA' AND
+        sl.fecha_inicio <= CURRENT_DATE() AND
+        (sl.fecha_fin IS NULL OR sl.fecha_fin >= CURRENT_DATE())
+      ))
+ORDER BY sl.id DESC
+LIMIT :per OFFSET :off";
+
+        $rows = DB::select($sql, $params);
+
+        $countSql = "SELECT COUNT(1) AS total
+FROM suscripciones_locales sl
+JOIN suscripciones s ON s.id = sl.suscripcion_id
+JOIN locales l ON l.id = sl.local_id AND l.deleted_at IS NULL
+JOIN empresas e ON e.id = l.empresa_id AND e.deleted_at IS NULL
+WHERE (:local_id IS NULL OR sl.local_id = :local_id)
+  AND (:estado IS NULL OR sl.estado = :estado)
+  AND (:vigentes IS NULL OR (
+        sl.estado = 'ACTIVA' AND
+        sl.fecha_inicio <= CURRENT_DATE() AND
+        (sl.fecha_fin IS NULL OR sl.fecha_fin >= CURRENT_DATE())
+      ))";
+
+        $total = DB::selectOne($countSql, $params)->total ?? 0;
+
+        return [
+            'data' => array_map(fn($r) => (array) $r, $rows),
+            'pagination' => [
+                'page' => $page,
+                'per_page' => $per,
+                'total' => (int) $total,
+            ],
+        ];
+    }
+
+    public function store(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'suscripcion_id' => ['required', 'integer'],
+            'local_id' => ['required', 'integer'],
+            'estado' => ['required'],
+            'fecha_inicio' => ['required', 'date'],
+            'fecha_fin' => ['nullable', 'date', 'after_or_equal:fecha_inicio'],
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => $validator->errors()->toArray(),
+            ], 422);
+        }
+        $data = $validator->validated();
+
+        $sus = DB::selectOne("SELECT id FROM suscripciones WHERE id = :id", ['id' => $data['suscripcion_id']]);
+        $loc = DB::selectOne("SELECT id FROM locales WHERE id = :id AND deleted_at IS NULL", ['id' => $data['local_id']]);
+        if (!$sus || !$loc) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => ['suscripcion_id' => !$sus ? ['suscripcion inexistente'] : null, 'local_id' => !$loc ? ['local inexistente'] : null],
+            ], 422);
+        }
+
+        $exists = DB::selectOne(
+            "SELECT id FROM suscripciones_locales WHERE suscripcion_id = :suscripcion_id AND local_id = :local_id",
+            ['suscripcion_id' => $data['suscripcion_id'], 'local_id' => $data['local_id']]
+        );
+        if ($exists) {
+            return response()->json([
+                'error' => 'Conflict',
+                'message' => 'Registro duplicado',
+            ], 409);
+        }
+
+        return DB::transaction(function () use ($data) {
+            DB::insert(
+                "INSERT INTO suscripciones_locales
+(suscripcion_id, local_id, estado, fecha_inicio, fecha_fin, created_at, updated_at)
+VALUES
+(:suscripcion_id, :local_id, :estado, :fecha_inicio, :fecha_fin, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                $data
+            );
+            $row = DB::selectOne("SELECT * FROM suscripciones_locales WHERE id = LAST_INSERT_ID()");
+            return ['data' => (array) $row];
+        });
+    }
+
+    public function show($id)
+    {
+        $row = DB::selectOne(
+            "SELECT sl.*
+FROM suscripciones_locales sl
+JOIN suscripciones s ON s.id = sl.suscripcion_id
+JOIN locales l ON l.id = sl.local_id AND l.deleted_at IS NULL
+JOIN empresas e ON e.id = l.empresa_id AND e.deleted_at IS NULL
+WHERE sl.id = :id
+LIMIT 1",
+            ['id' => $id]
+        );
+        if (!$row) {
+            return response()->json([
+                'error' => 'NotFound',
+                'message' => 'Recurso no encontrado',
+            ], 404);
+        }
+        return ['data' => (array) $row];
+    }
+
+    public function update(Request $request, $id)
+    {
+        $validator = Validator::make($request->all(), [
+            'estado' => ['required'],
+            'fecha_inicio' => ['required', 'date'],
+            'fecha_fin' => ['nullable', 'date', 'after_or_equal:fecha_inicio'],
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => $validator->errors()->toArray(),
+            ], 422);
+        }
+        $data = $validator->validated();
+        $data['id'] = $id;
+
+        return DB::transaction(function () use ($data, $id) {
+            $affected = DB::update(
+                "UPDATE suscripciones_locales
+SET estado = :estado,
+    fecha_inicio = :fecha_inicio,
+    fecha_fin = :fecha_fin,
+    updated_at = CURRENT_TIMESTAMP
+WHERE id = :id",
+                $data
+            );
+            if (!$affected) {
+                return response()->json([
+                    'error' => 'NotFound',
+                    'message' => 'Recurso no encontrado',
+                ], 404);
+            }
+            $row = DB::selectOne("SELECT * FROM suscripciones_locales WHERE id = :id", ['id' => $id]);
+            return ['data' => (array) $row];
+        });
+    }
+}

--- a/app/Http/Middleware/CheckSubscription.php
+++ b/app/Http/Middleware/CheckSubscription.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class CheckSubscription
+{
+    public function handle(Request $request, Closure $next)
+    {
+        $user = $request->user();
+        $localId = $user->local_id ?? null;
+        if (!$localId) {
+            return response()->json(['message' => 'Subscription inactive'], 403);
+        }
+
+        $row = DB::selectOne(
+            "SELECT
+  CASE
+    WHEN e.activo = 1
+     AND l.activo = 1
+     AND EXISTS (
+       SELECT 1
+       FROM suscripciones s
+       WHERE s.empresa_id = e.id
+         AND s.estado = 'ACTIVA'
+         AND s.fecha_inicio <= CURRENT_DATE()
+         AND (s.fecha_fin IS NULL OR s.fecha_fin >= CURRENT_DATE())
+     )
+     AND EXISTS (
+       SELECT 1
+       FROM suscripciones_locales sl
+       JOIN suscripciones s2 ON s2.id = sl.suscripcion_id
+       WHERE sl.local_id = l.id
+         AND sl.estado = 'ACTIVA'
+         AND sl.fecha_inicio <= CURRENT_DATE()
+         AND (sl.fecha_fin IS NULL OR sl.fecha_fin >= CURRENT_DATE())
+         AND s2.estado = 'ACTIVA'
+         AND s2.fecha_inicio <= CURRENT_DATE()
+         AND (s2.fecha_fin IS NULL OR s2.fecha_fin >= CURRENT_DATE())
+     )
+    THEN 1 ELSE 0
+  END AS vigente
+FROM locales l
+JOIN empresas e ON e.id = l.empresa_id
+WHERE l.id = :local_id
+  AND e.deleted_at IS NULL
+  AND l.deleted_at IS NULL
+LIMIT 1",
+            ['local_id' => $localId]
+        );
+
+        if (!$row || $row->vigente != 1) {
+            return response()->json(['message' => 'Subscription inactive'], 403);
+        }
+
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -14,6 +14,7 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->alias([
             'auth.jwt' => \App\Http\Middleware\JwtMiddleware::class,
+            'check.subscription' => \App\Http\Middleware\CheckSubscription::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,11 @@
 
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\AuthController;
+use App\Http\Controllers\Tenancy\EmpresaController;
+use App\Http\Controllers\Tenancy\LocalController;
+use App\Http\Controllers\Tenancy\SuscripcionController;
+use App\Http\Controllers\Tenancy\SuscripcionLocalController;
+use App\Http\Controllers\Tenancy\SubscriptionStatusController;
 
 Route::prefix('v1/auth')->group(function () {
     Route::post('/login', [AuthController::class, 'login']);
@@ -10,4 +15,32 @@ Route::prefix('v1/auth')->group(function () {
     Route::post('/refresh', [AuthController::class, 'refresh']);
     Route::post('/change-password', [AuthController::class, 'changePassword'])->middleware('auth.jwt');
     Route::post('/force-invalidate', [AuthController::class, 'forceInvalidate'])->middleware('auth.jwt');
+});
+
+Route::prefix('v1')->middleware('auth.jwt')->group(function () {
+    Route::middleware('check.subscription')->group(function () {
+        Route::get('/empresas', [EmpresaController::class, 'index']);
+        Route::post('/empresas', [EmpresaController::class, 'store']);
+        Route::get('/empresas/{id}', [EmpresaController::class, 'show']);
+        Route::put('/empresas/{id}', [EmpresaController::class, 'update']);
+        Route::delete('/empresas/{id}', [EmpresaController::class, 'destroy']);
+
+        Route::get('/locales', [LocalController::class, 'index']);
+        Route::post('/locales', [LocalController::class, 'store']);
+        Route::get('/locales/{id}', [LocalController::class, 'show']);
+        Route::put('/locales/{id}', [LocalController::class, 'update']);
+        Route::delete('/locales/{id}', [LocalController::class, 'destroy']);
+
+        Route::get('/suscripciones', [SuscripcionController::class, 'index']);
+        Route::post('/suscripciones', [SuscripcionController::class, 'store']);
+        Route::get('/suscripciones/{id}', [SuscripcionController::class, 'show']);
+        Route::put('/suscripciones/{id}', [SuscripcionController::class, 'update']);
+
+        Route::get('/suscripciones-locales', [SuscripcionLocalController::class, 'index']);
+        Route::post('/suscripciones-locales', [SuscripcionLocalController::class, 'store']);
+        Route::get('/suscripciones-locales/{id}', [SuscripcionLocalController::class, 'show']);
+        Route::put('/suscripciones-locales/{id}', [SuscripcionLocalController::class, 'update']);
+    });
+
+    Route::get('/estado-suscripcion', SubscriptionStatusController::class);
 });


### PR DESCRIPTION
## Summary
- add Tenancy controllers for empresas, locales, suscripciones, and suscripciones-locales
- add subscription status check endpoint and subscription middleware
- wire tenancy routes and middleware aliases

## Testing
- `composer test` *(fails: Failed to open stream: No such file or directory)*
- `composer install` *(fails: requires GitHub token for packages)*

------
https://chatgpt.com/codex/tasks/task_e_6897b31ec1ac832f8a1efac9f903e25e