### PR TITLE
Add catalog management endpoints

### DIFF
--- a/app/Http/Controllers/CategoriaProductoController.php
+++ b/app/Http/Controllers/CategoriaProductoController.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+
+class CategoriaProductoController extends Controller
+{
+    public function index(Request $request)
+    {
+        $page = max((int) $request->query('page', 1), 1);
+        $per = (int) $request->query('per_page', 20);
+        $per = $per > 100 ? 100 : $per;
+        $off = ($page - 1) * $per;
+
+        $empresa_id = $request->query('empresa_id');
+        $padre_id = $request->query('padre_id');
+        $q = $request->query('q');
+
+        $params = [
+            'empresa_id' => $empresa_id,
+            'padre_id' => $padre_id,
+            'q' => $q,
+            'per' => $per,
+            'off' => $off,
+        ];
+
+        $sql = "SELECT c.*
+FROM categorias_producto c
+WHERE c.empresa_id = :empresa_id
+  AND (:padre_id IS NULL OR c.padre_id = :padre_id)
+  AND (:q IS NULL OR c.nombre LIKE CONCAT('%', :q, '%'))
+ORDER BY COALESCE(c.orden, 9999) ASC, c.nombre ASC
+LIMIT :per OFFSET :off";
+
+        $rows = DB::select($sql, $params);
+
+        $countSql = "SELECT COUNT(1) AS total
+FROM categorias_producto c
+WHERE c.empresa_id = :empresa_id
+  AND (:padre_id IS NULL OR c.padre_id = :padre_id)
+  AND (:q IS NULL OR c.nombre LIKE CONCAT('%', :q, '%'))";
+
+        $total = DB::selectOne($countSql, $params)->total ?? 0;
+
+        return [
+            'data' => array_map(fn($r) => (array) $r, $rows),
+            'pagination' => [
+                'page' => $page,
+                'per_page' => $per,
+                'total' => (int) $total,
+            ],
+        ];
+    }
+
+    public function store(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'empresa_id' => ['required', 'integer'],
+            'nombre' => ['required'],
+            'padre_id' => ['nullable', 'integer'],
+            'orden' => ['nullable', 'integer'],
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => $validator->errors()->toArray(),
+            ], 422);
+        }
+        $data = $validator->validated();
+
+        // validate padre_id
+        if (!empty($data['padre_id'])) {
+            $parent = DB::selectOne("SELECT id FROM categorias_producto WHERE id = :padre_id AND empresa_id = :empresa_id", [
+                'padre_id' => $data['padre_id'],
+                'empresa_id' => $data['empresa_id'],
+            ]);
+            if (!$parent) {
+                return response()->json([
+                    'error' => 'Validation',
+                    'fields' => ['padre_id' => ['Inválido']],
+                ], 422);
+            }
+        }
+
+        $exists = DB::selectOne(
+            "SELECT id FROM categorias_producto WHERE empresa_id = :empresa_id AND nombre = :nombre",
+            ['empresa_id' => $data['empresa_id'], 'nombre' => $data['nombre']]
+        );
+        if ($exists) {
+            return response()->json([
+                'error' => 'Conflict',
+                'message' => 'Duplicado',
+            ], 409);
+        }
+
+        return DB::transaction(function () use ($data) {
+            DB::insert(
+                "INSERT INTO categorias_producto (empresa_id, nombre, padre_id, orden, created_at, updated_at)
+VALUES (:empresa_id, :nombre, :padre_id, :orden, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                [
+                    'empresa_id' => $data['empresa_id'],
+                    'nombre' => $data['nombre'],
+                    'padre_id' => $data['padre_id'] ?? null,
+                    'orden' => $data['orden'] ?? null,
+                ]
+            );
+            $row = DB::selectOne("SELECT * FROM categorias_producto WHERE id = LAST_INSERT_ID()");
+            return ['data' => (array) $row];
+        });
+    }
+
+    public function show($id)
+    {
+        $row = DB::selectOne("SELECT * FROM categorias_producto WHERE id = :id LIMIT 1", ['id' => $id]);
+        if (!$row) {
+            return response()->json([
+                'error' => 'NotFound',
+                'message' => 'Recurso no encontrado',
+            ], 404);
+        }
+        return ['data' => (array) $row];
+    }
+
+    public function update(Request $request, $id)
+    {
+        $validator = Validator::make($request->all(), [
+            'nombre' => ['required'],
+            'padre_id' => ['nullable', 'integer'],
+            'orden' => ['nullable', 'integer'],
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => $validator->errors()->toArray(),
+            ], 422);
+        }
+        $row = DB::selectOne("SELECT * FROM categorias_producto WHERE id = :id", ['id' => $id]);
+        if (!$row) {
+            return response()->json([
+                'error' => 'NotFound',
+                'message' => 'Recurso no encontrado',
+            ], 404);
+        }
+
+        $data = $validator->validated();
+        // padre_id validation
+        if (!empty($data['padre_id'])) {
+            if ($data['padre_id'] == $id) {
+                return response()->json([
+                    'error' => 'Validation',
+                    'fields' => ['padre_id' => ['Inválido']],
+                ], 422);
+            }
+            $parent = DB::selectOne("SELECT id FROM categorias_producto WHERE id = :padre_id AND empresa_id = :empresa_id", [
+                'padre_id' => $data['padre_id'],
+                'empresa_id' => $row->empresa_id,
+            ]);
+            if (!$parent) {
+                return response()->json([
+                    'error' => 'Validation',
+                    'fields' => ['padre_id' => ['Inválido']],
+                ], 422);
+            }
+        }
+
+        if ($data['nombre'] !== $row->nombre) {
+            $exists = DB::selectOne(
+                "SELECT id FROM categorias_producto WHERE empresa_id = :empresa_id AND nombre = :nombre AND id <> :id",
+                ['empresa_id' => $row->empresa_id, 'nombre' => $data['nombre'], 'id' => $id]
+            );
+            if ($exists) {
+                return response()->json([
+                    'error' => 'Conflict',
+                    'message' => 'Duplicado',
+                ], 409);
+            }
+        }
+
+        DB::update(
+            "UPDATE categorias_producto
+SET nombre = :nombre,
+    padre_id = :padre_id,
+    orden = :orden,
+    updated_at = CURRENT_TIMESTAMP
+WHERE id = :id",
+            [
+                'nombre' => $data['nombre'],
+                'padre_id' => $data['padre_id'] ?? null,
+                'orden' => $data['orden'] ?? null,
+                'id' => $id,
+            ]
+        );
+        $row = DB::selectOne("SELECT * FROM categorias_producto WHERE id = :id", ['id' => $id]);
+        return ['data' => (array) $row];
+    }
+
+    public function destroy($id)
+    {
+        $row = DB::selectOne("SELECT id FROM categorias_producto WHERE id = :id", ['id' => $id]);
+        if (!$row) {
+            return response()->json([
+                'error' => 'NotFound',
+                'message' => 'Recurso no encontrado',
+            ], 404);
+        }
+
+        $child = DB::selectOne("SELECT id FROM categorias_producto WHERE padre_id = :id LIMIT 1", ['id' => $id]);
+        if ($child) {
+            return response()->json([
+                'error' => 'Conflict',
+                'message' => 'Tiene relaciones',
+            ], 409);
+        }
+        $ref = DB::selectOne("SELECT id FROM productos WHERE categoria_id = :id LIMIT 1", ['id' => $id]);
+        if ($ref) {
+            return response()->json([
+                'error' => 'Conflict',
+                'message' => 'Tiene relaciones',
+            ], 409);
+        }
+
+        DB::delete("DELETE FROM categorias_producto WHERE id = :id", ['id' => $id]);
+        return response()->json(null, 204);
+    }
+}
+

--- a/app/Http/Controllers/ImpuestoController.php
+++ b/app/Http/Controllers/ImpuestoController.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+
+class ImpuestoController extends Controller
+{
+    public function index(Request $request)
+    {
+        $page = max((int) $request->query('page', 1), 1);
+        $per = (int) $request->query('per_page', 20);
+        $per = $per > 100 ? 100 : $per;
+        $off = ($page - 1) * $per;
+
+        $empresa_id = $request->query('empresa_id');
+        $tipo = $request->query('tipo');
+        $vigente = $request->query('vigente');
+        $q = $request->query('q');
+
+        $params = [
+            'empresa_id' => $empresa_id,
+            'tipo' => $tipo,
+            'vigente' => $vigente,
+            'q' => $q,
+            'per' => $per,
+            'off' => $off,
+        ];
+
+        $sql = "SELECT i.*
+FROM impuestos i
+WHERE ((:empresa_id IS NULL AND i.empresa_id IS NULL) OR (i.empresa_id = :empresa_id OR i.empresa_id IS NULL))
+  AND (:tipo IS NULL OR i.tipo = :tipo)
+  AND (:vigente IS NULL OR i.vigente = :vigente)
+  AND (:q IS NULL OR (i.codigo LIKE CONCAT('%', :q, '%') OR i.nombre LIKE CONCAT('%', :q, '%')))
+ORDER BY i.id DESC
+LIMIT :per OFFSET :off";
+
+        $rows = DB::select($sql, $params);
+
+        $countSql = "SELECT COUNT(1) AS total
+FROM impuestos i
+WHERE ((:empresa_id IS NULL AND i.empresa_id IS NULL) OR (i.empresa_id = :empresa_id OR i.empresa_id IS NULL))
+  AND (:tipo IS NULL OR i.tipo = :tipo)
+  AND (:vigente IS NULL OR i.vigente = :vigente)
+  AND (:q IS NULL OR (i.codigo LIKE CONCAT('%', :q, '%') OR i.nombre LIKE CONCAT('%', :q, '%')))";
+
+        $total = DB::selectOne($countSql, $params)->total ?? 0;
+
+        return [
+            'data' => array_map(fn($r) => (array) $r, $rows),
+            'pagination' => [
+                'page' => $page,
+                'per_page' => $per,
+                'total' => (int) $total,
+            ],
+        ];
+    }
+
+    public function store(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'empresa_id' => ['nullable', 'integer'],
+            'codigo' => ['required'],
+            'nombre' => ['required'],
+            'tipo' => ['required', 'in:IVA,ICE,IRBPNR,OTRO'],
+            'porcentaje' => ['required', 'numeric', 'min:0', 'max:1000'],
+            'vigente' => ['boolean'],
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => $validator->errors()->toArray(),
+            ], 422);
+        }
+        $data = $validator->validated();
+        $data['vigente'] = $data['vigente'] ?? 1;
+
+        $exists = DB::selectOne(
+            "SELECT id FROM impuestos WHERE ((empresa_id IS NULL AND :empresa_id IS NULL) OR empresa_id = :empresa_id) AND codigo = :codigo",
+            ['empresa_id' => $data['empresa_id'] ?? null, 'codigo' => $data['codigo']]
+        );
+        if ($exists) {
+            return response()->json([
+                'error' => 'Conflict',
+                'message' => 'Duplicado',
+            ], 409);
+        }
+
+        return DB::transaction(function () use ($data) {
+            DB::insert(
+                "INSERT INTO impuestos (empresa_id, codigo, nombre, tipo, porcentaje, vigente, created_at, updated_at)
+VALUES (:empresa_id, :codigo, :nombre, :tipo, :porcentaje, :vigente, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                [
+                    'empresa_id' => $data['empresa_id'] ?? null,
+                    'codigo' => $data['codigo'],
+                    'nombre' => $data['nombre'],
+                    'tipo' => $data['tipo'],
+                    'porcentaje' => $data['porcentaje'],
+                    'vigente' => $data['vigente'],
+                ]
+            );
+            $row = DB::selectOne("SELECT * FROM impuestos WHERE id = LAST_INSERT_ID()");
+            return ['data' => (array) $row];
+        });
+    }
+
+    public function show($id)
+    {
+        $row = DB::selectOne("SELECT * FROM impuestos WHERE id = :id LIMIT 1", ['id' => $id]);
+        if (!$row) {
+            return response()->json([
+                'error' => 'NotFound',
+                'message' => 'Recurso no encontrado',
+            ], 404);
+        }
+        return ['data' => (array) $row];
+    }
+
+    public function update(Request $request, $id)
+    {
+        $validator = Validator::make($request->all(), [
+            'codigo' => ['required'],
+            'nombre' => ['required'],
+            'tipo' => ['required', 'in:IVA,ICE,IRBPNR,OTRO'],
+            'porcentaje' => ['required', 'numeric', 'min:0', 'max:1000'],
+            'vigente' => ['boolean'],
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => $validator->errors()->toArray(),
+            ], 422);
+        }
+        $row = DB::selectOne("SELECT * FROM impuestos WHERE id = :id", ['id' => $id]);
+        if (!$row) {
+            return response()->json([
+                'error' => 'NotFound',
+                'message' => 'Recurso no encontrado',
+            ], 404);
+        }
+
+        $data = $validator->validated();
+        $data['vigente'] = $data['vigente'] ?? 1;
+
+        if ($data['codigo'] !== $row->codigo) {
+            $exists = DB::selectOne(
+                "SELECT id FROM impuestos WHERE ((empresa_id IS NULL AND :empresa_id IS NULL) OR empresa_id = :empresa_id) AND codigo = :codigo AND id <> :id",
+                ['empresa_id' => $row->empresa_id, 'codigo' => $data['codigo'], 'id' => $id]
+            );
+            if ($exists) {
+                return response()->json([
+                    'error' => 'Conflict',
+                    'message' => 'Duplicado',
+                ], 409);
+            }
+        }
+
+        DB::update(
+            "UPDATE impuestos
+SET codigo = :codigo,
+    nombre = :nombre,
+    tipo = :tipo,
+    porcentaje = :porcentaje,
+    vigente = :vigente,
+    updated_at = CURRENT_TIMESTAMP
+WHERE id = :id",
+            [
+                'codigo' => $data['codigo'],
+                'nombre' => $data['nombre'],
+                'tipo' => $data['tipo'],
+                'porcentaje' => $data['porcentaje'],
+                'vigente' => $data['vigente'],
+                'id' => $id,
+            ]
+        );
+        $row = DB::selectOne("SELECT * FROM impuestos WHERE id = :id", ['id' => $id]);
+        return ['data' => (array) $row];
+    }
+
+    public function destroy($id)
+    {
+        $row = DB::selectOne("SELECT id FROM impuestos WHERE id = :id", ['id' => $id]);
+        if (!$row) {
+            return response()->json([
+                'error' => 'NotFound',
+                'message' => 'Recurso no encontrado',
+            ], 404);
+        }
+
+        $ref1 = DB::selectOne("SELECT id FROM productos WHERE impuesto_id = :id LIMIT 1", ['id' => $id]);
+        $ref2 = DB::selectOne("SELECT id FROM facturas WHERE impuesto_id = :id LIMIT 1", ['id' => $id]);
+        if ($ref1 || $ref2) {
+            return response()->json([
+                'error' => 'Conflict',
+                'message' => 'Tiene relaciones',
+            ], 409);
+        }
+
+        DB::delete("DELETE FROM impuestos WHERE id = :id", ['id' => $id]);
+        return response()->json(null, 204);
+    }
+}
+

--- a/app/Http/Controllers/MetodoPagoController.php
+++ b/app/Http/Controllers/MetodoPagoController.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+
+class MetodoPagoController extends Controller
+{
+    public function index(Request $request)
+    {
+        $page = max((int) $request->query('page', 1), 1);
+        $per = (int) $request->query('per_page', 20);
+        $per = $per > 100 ? 100 : $per;
+        $off = ($page - 1) * $per;
+
+        $empresa_id = $request->query('empresa_id');
+        $activo = $request->query('activo');
+        $q = $request->query('q');
+
+        $params = [
+            'empresa_id' => $empresa_id,
+            'activo' => $activo,
+            'q' => $q,
+            'per' => $per,
+            'off' => $off,
+        ];
+
+        $sql = "SELECT mp.*
+FROM metodos_pago mp
+WHERE ((:empresa_id IS NULL AND mp.empresa_id IS NULL) OR (mp.empresa_id = :empresa_id OR mp.empresa_id IS NULL))
+  AND (:activo IS NULL OR mp.activo = :activo)
+  AND (:q IS NULL OR (mp.nombre LIKE CONCAT('%', :q, '%')))
+ORDER BY mp.id DESC
+LIMIT :per OFFSET :off";
+
+        $rows = DB::select($sql, $params);
+
+        $countSql = "SELECT COUNT(1) AS total
+FROM metodos_pago mp
+WHERE ((:empresa_id IS NULL AND mp.empresa_id IS NULL) OR (mp.empresa_id = :empresa_id OR mp.empresa_id IS NULL))
+  AND (:activo IS NULL OR mp.activo = :activo)
+  AND (:q IS NULL OR (mp.nombre LIKE CONCAT('%', :q, '%')))";
+
+        $total = DB::selectOne($countSql, $params)->total ?? 0;
+
+        return [
+            'data' => array_map(fn($r) => (array) $r, $rows),
+            'pagination' => [
+                'page' => $page,
+                'per_page' => $per,
+                'total' => (int) $total,
+            ],
+        ];
+    }
+
+    public function store(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'empresa_id' => ['nullable', 'integer'],
+            'nombre' => ['required'],
+            'activo' => ['boolean'],
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => $validator->errors()->toArray(),
+            ], 422);
+        }
+        $data = $validator->validated();
+        $data['activo'] = $data['activo'] ?? 1;
+
+        $exists = DB::selectOne(
+            "SELECT id FROM metodos_pago WHERE ((empresa_id IS NULL AND :empresa_id IS NULL) OR empresa_id = :empresa_id) AND nombre = :nombre",
+            ['empresa_id' => $data['empresa_id'] ?? null, 'nombre' => $data['nombre']]
+        );
+        if ($exists) {
+            return response()->json([
+                'error' => 'Conflict',
+                'message' => 'Duplicado',
+            ], 409);
+        }
+
+        return DB::transaction(function () use ($data) {
+            DB::insert(
+                "INSERT INTO metodos_pago (empresa_id, nombre, activo, created_at, updated_at)
+VALUES (:empresa_id, :nombre, :activo, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                [
+                    'empresa_id' => $data['empresa_id'] ?? null,
+                    'nombre' => $data['nombre'],
+                    'activo' => $data['activo'],
+                ]
+            );
+            $row = DB::selectOne("SELECT * FROM metodos_pago WHERE id = LAST_INSERT_ID()");
+            return ['data' => (array) $row];
+        });
+    }
+
+    public function show($id)
+    {
+        $row = DB::selectOne("SELECT * FROM metodos_pago WHERE id = :id LIMIT 1", ['id' => $id]);
+        if (!$row) {
+            return response()->json([
+                'error' => 'NotFound',
+                'message' => 'Recurso no encontrado',
+            ], 404);
+        }
+        return ['data' => (array) $row];
+    }
+
+    public function update(Request $request, $id)
+    {
+        $validator = Validator::make($request->all(), [
+            'nombre' => ['required'],
+            'activo' => ['boolean'],
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => $validator->errors()->toArray(),
+            ], 422);
+        }
+        $row = DB::selectOne("SELECT * FROM metodos_pago WHERE id = :id", ['id' => $id]);
+        if (!$row) {
+            return response()->json([
+                'error' => 'NotFound',
+                'message' => 'Recurso no encontrado',
+            ], 404);
+        }
+
+        $data = $validator->validated();
+        $data['activo'] = $data['activo'] ?? 1;
+        if ($data['nombre'] !== $row->nombre) {
+            $exists = DB::selectOne(
+                "SELECT id FROM metodos_pago WHERE ((empresa_id IS NULL AND :empresa_id IS NULL) OR empresa_id = :empresa_id) AND nombre = :nombre AND id <> :id",
+                ['empresa_id' => $row->empresa_id, 'nombre' => $data['nombre'], 'id' => $id]
+            );
+            if ($exists) {
+                return response()->json([
+                    'error' => 'Conflict',
+                    'message' => 'Duplicado',
+                ], 409);
+            }
+        }
+
+        DB::update(
+            "UPDATE metodos_pago
+SET nombre = :nombre,
+    activo = :activo,
+    updated_at = CURRENT_TIMESTAMP
+WHERE id = :id",
+            [
+                'nombre' => $data['nombre'],
+                'activo' => $data['activo'],
+                'id' => $id,
+            ]
+        );
+        $row = DB::selectOne("SELECT * FROM metodos_pago WHERE id = :id", ['id' => $id]);
+        return ['data' => (array) $row];
+    }
+
+    public function destroy($id)
+    {
+        $row = DB::selectOne("SELECT id FROM metodos_pago WHERE id = :id", ['id' => $id]);
+        if (!$row) {
+            return response()->json([
+                'error' => 'NotFound',
+                'message' => 'Recurso no encontrado',
+            ], 404);
+        }
+
+        $ref1 = DB::selectOne("SELECT id FROM pagos_venta WHERE metodo_pago_id = :id LIMIT 1", ['id' => $id]);
+        $ref2 = DB::selectOne("SELECT id FROM pagos_proveedor WHERE metodo_pago_id = :id LIMIT 1", ['id' => $id]);
+        if ($ref1 || $ref2) {
+            return response()->json([
+                'error' => 'Conflict',
+                'message' => 'Tiene relaciones',
+            ], 409);
+        }
+
+        DB::delete("DELETE FROM metodos_pago WHERE id = :id", ['id' => $id]);
+        return response()->json(null, 204);
+    }
+}
+

--- a/app/Http/Controllers/UnidadMedidaController.php
+++ b/app/Http/Controllers/UnidadMedidaController.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+
+class UnidadMedidaController extends Controller
+{
+    public function index(Request $request)
+    {
+        $page = max((int) $request->query('page', 1), 1);
+        $per = (int) $request->query('per_page', 20);
+        $per = $per > 100 ? 100 : $per;
+        $off = ($page - 1) * $per;
+
+        $empresa_id = $request->query('empresa_id');
+        $q = $request->query('q');
+
+        $params = [
+            'empresa_id' => $empresa_id,
+            'q' => $q,
+            'per' => $per,
+            'off' => $off,
+        ];
+
+        $sql = "SELECT um.*
+FROM unidades_medida um
+WHERE (:empresa_id IS NULL AND um.empresa_id IS NOT NULL OR :empresa_id IS NOT NULL)
+  AND (
+       (:empresa_id IS NULL AND 1=1)
+       OR (um.empresa_id = :empresa_id OR um.empresa_id IS NULL)
+      )
+  AND (:q IS NULL OR (um.nombre LIKE CONCAT('%', :q, '%') OR um.abreviatura LIKE CONCAT('%', :q, '%')))
+ORDER BY um.id DESC
+LIMIT :per OFFSET :off";
+
+        $rows = DB::select($sql, $params);
+
+        $countSql = "SELECT COUNT(1) AS total
+FROM unidades_medida um
+WHERE (:empresa_id IS NULL AND um.empresa_id IS NOT NULL OR :empresa_id IS NOT NULL)
+  AND ((:empresa_id IS NULL AND 1=1) OR (um.empresa_id = :empresa_id OR um.empresa_id IS NULL))
+  AND (:q IS NULL OR (um.nombre LIKE CONCAT('%', :q, '%') OR um.abreviatura LIKE CONCAT('%', :q, '%')));";
+
+        $total = DB::selectOne($countSql, $params)->total ?? 0;
+
+        return [
+            'data' => array_map(fn($r) => (array) $r, $rows),
+            'pagination' => [
+                'page' => $page,
+                'per_page' => $per,
+                'total' => (int) $total,
+            ],
+        ];
+    }
+
+    public function store(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'empresa_id' => ['nullable', 'integer'],
+            'nombre' => ['required'],
+            'abreviatura' => ['required'],
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => $validator->errors()->toArray(),
+            ], 422);
+        }
+
+        $data = $validator->validated();
+
+        $exists = DB::selectOne(
+            "SELECT id FROM unidades_medida WHERE (empresa_id <=> :empresa_id) AND abreviatura = :abreviatura",
+            ['empresa_id' => $data['empresa_id'] ?? null, 'abreviatura' => $data['abreviatura']]
+        );
+        if ($exists) {
+            return response()->json([
+                'error' => 'Conflict',
+                'message' => 'Duplicado',
+            ], 409);
+        }
+
+        return DB::transaction(function () use ($data) {
+            DB::insert(
+                "INSERT INTO unidades_medida (empresa_id, nombre, abreviatura, created_at, updated_at)
+VALUES (:empresa_id, :nombre, :abreviatura, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                [
+                    'empresa_id' => $data['empresa_id'] ?? null,
+                    'nombre' => $data['nombre'],
+                    'abreviatura' => $data['abreviatura'],
+                ]
+            );
+            $row = DB::selectOne("SELECT * FROM unidades_medida WHERE id = LAST_INSERT_ID()");
+            return ['data' => (array) $row];
+        });
+    }
+
+    public function show($id)
+    {
+        $row = DB::selectOne(
+            "SELECT * FROM unidades_medida WHERE id = :id LIMIT 1",
+            ['id' => $id]
+        );
+        if (!$row) {
+            return response()->json([
+                'error' => 'NotFound',
+                'message' => 'Recurso no encontrado',
+            ], 404);
+        }
+        return ['data' => (array) $row];
+    }
+
+    public function update(Request $request, $id)
+    {
+        $validator = Validator::make($request->all(), [
+            'nombre' => ['required'],
+            'abreviatura' => ['required'],
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => $validator->errors()->toArray(),
+            ], 422);
+        }
+        $row = DB::selectOne("SELECT * FROM unidades_medida WHERE id = :id", ['id' => $id]);
+        if (!$row) {
+            return response()->json([
+                'error' => 'NotFound',
+                'message' => 'Recurso no encontrado',
+            ], 404);
+        }
+
+        $data = $validator->validated();
+        if ($data['abreviatura'] !== $row->abreviatura) {
+            $exists = DB::selectOne(
+                "SELECT id FROM unidades_medida WHERE (empresa_id <=> :empresa_id) AND abreviatura = :abreviatura AND id <> :id",
+                ['empresa_id' => $row->empresa_id, 'abreviatura' => $data['abreviatura'], 'id' => $id]
+            );
+            if ($exists) {
+                return response()->json([
+                    'error' => 'Conflict',
+                    'message' => 'Duplicado',
+                ], 409);
+            }
+        }
+
+        DB::update(
+            "UPDATE unidades_medida
+SET nombre = :nombre,
+    abreviatura = :abreviatura,
+    updated_at = CURRENT_TIMESTAMP
+WHERE id = :id",
+            [
+                'nombre' => $data['nombre'],
+                'abreviatura' => $data['abreviatura'],
+                'id' => $id,
+            ]
+        );
+        $row = DB::selectOne("SELECT * FROM unidades_medida WHERE id = :id", ['id' => $id]);
+        return ['data' => (array) $row];
+    }
+
+    public function destroy($id)
+    {
+        $row = DB::selectOne("SELECT id FROM unidades_medida WHERE id = :id", ['id' => $id]);
+        if (!$row) {
+            return response()->json([
+                'error' => 'NotFound',
+                'message' => 'Recurso no encontrado',
+            ], 404);
+        }
+
+        $ref = DB::selectOne("SELECT id FROM productos WHERE unidad_id = :id LIMIT 1", ['id' => $id]);
+        if ($ref) {
+            return response()->json([
+                'error' => 'Conflict',
+                'message' => 'Tiene relaciones',
+            ], 409);
+        }
+
+        DB::delete("DELETE FROM unidades_medida WHERE id = :id", ['id' => $id]);
+        return response()->json(null, 204);
+    }
+}
+

--- a/routes/api.php
+++ b/routes/api.php
@@ -10,6 +10,10 @@ use App\Http\Controllers\Tenancy\SubscriptionStatusController;
 use App\Http\Controllers\UsuarioController;
 use App\Http\Controllers\RolController;
 use App\Http\Controllers\PermisoController;
+use App\Http\Controllers\UnidadMedidaController;
+use App\Http\Controllers\ImpuestoController;
+use App\Http\Controllers\MetodoPagoController;
+use App\Http\Controllers\CategoriaProductoController;
 
 Route::prefix('v1/auth')->group(function () {
     Route::post('/login', [AuthController::class, 'login']);
@@ -62,6 +66,30 @@ Route::prefix('v1')->middleware('auth.jwt')->group(function () {
         Route::get('/permisos/{id}', [PermisoController::class, 'show']);
         Route::put('/permisos/{id}', [PermisoController::class, 'update']);
         Route::delete('/permisos/{id}', [PermisoController::class, 'destroy']);
+
+        Route::get('/unidades', [UnidadMedidaController::class, 'index'])->middleware('can:productos.crear_editar');
+        Route::post('/unidades', [UnidadMedidaController::class, 'store'])->middleware('can:productos.crear_editar');
+        Route::get('/unidades/{id}', [UnidadMedidaController::class, 'show'])->middleware('can:productos.crear_editar');
+        Route::put('/unidades/{id}', [UnidadMedidaController::class, 'update'])->middleware('can:productos.crear_editar');
+        Route::delete('/unidades/{id}', [UnidadMedidaController::class, 'destroy'])->middleware('can:productos.crear_editar');
+
+        Route::get('/impuestos', [ImpuestoController::class, 'index'])->middleware('can:productos.crear_editar');
+        Route::post('/impuestos', [ImpuestoController::class, 'store'])->middleware('can:productos.crear_editar');
+        Route::get('/impuestos/{id}', [ImpuestoController::class, 'show'])->middleware('can:productos.crear_editar');
+        Route::put('/impuestos/{id}', [ImpuestoController::class, 'update'])->middleware('can:productos.crear_editar');
+        Route::delete('/impuestos/{id}', [ImpuestoController::class, 'destroy'])->middleware('can:productos.crear_editar');
+
+        Route::get('/metodos-pago', [MetodoPagoController::class, 'index'])->middleware('can:caja.cobrar');
+        Route::post('/metodos-pago', [MetodoPagoController::class, 'store'])->middleware('can:config.locales.gestionar');
+        Route::get('/metodos-pago/{id}', [MetodoPagoController::class, 'show'])->middleware('can:caja.cobrar');
+        Route::put('/metodos-pago/{id}', [MetodoPagoController::class, 'update'])->middleware('can:config.locales.gestionar');
+        Route::delete('/metodos-pago/{id}', [MetodoPagoController::class, 'destroy'])->middleware('can:config.locales.gestionar');
+
+        Route::get('/categorias', [CategoriaProductoController::class, 'index'])->middleware('can:productos.crear_editar');
+        Route::post('/categorias', [CategoriaProductoController::class, 'store'])->middleware('can:productos.crear_editar');
+        Route::get('/categorias/{id}', [CategoriaProductoController::class, 'show'])->middleware('can:productos.crear_editar');
+        Route::put('/categorias/{id}', [CategoriaProductoController::class, 'update'])->middleware('can:productos.crear_editar');
+        Route::delete('/categorias/{id}', [CategoriaProductoController::class, 'destroy'])->middleware('can:productos.crear_editar');
     });
 
     Route::get('/estado-suscripcion', SubscriptionStatusController::class);


### PR DESCRIPTION
## Summary
- add CRUD controllers for measurement units, taxes, payment methods and product categories
- expose catalog routes with permission middleware

## Testing
- `composer test` *(fails: Script @php artisan config:clear --ansi handling the test event returned with error code 255)*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6897b6c48a38832f8c0abb1bbfe6fc53