### PR TITLE
feat(api): add clientes and proveedores endpoints

### DIFF
--- a/app/Http/Controllers/ClienteController.php
+++ b/app/Http/Controllers/ClienteController.php
@@ -1,0 +1,259 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreClienteRequest;
+use App\Http\Requests\UpdateClienteRequest;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+
+class ClienteController extends Controller
+{
+    public function index(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'empresa_id' => ['required', 'integer'],
+            'q' => ['nullable', 'string'],
+            'activo' => ['nullable', 'in:0,1'],
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => $validator->errors()->toArray(),
+            ], 422);
+        }
+        $page = max((int) $request->query('page', 1), 1);
+        $per = (int) $request->query('per_page', 20);
+        $per = $per > 100 ? 100 : $per;
+        $off = ($page - 1) * $per;
+
+        $empresa_id = (int) $request->query('empresa_id');
+        $q = $request->query('q');
+        $activo = $request->query('activo');
+
+        $params = [
+            'empresa_id' => $empresa_id,
+            'q' => $q,
+            'activo' => $activo,
+            'per' => $per,
+            'off' => $off,
+        ];
+
+        $sql = "SELECT c.*
+FROM clientes c
+WHERE c.empresa_id = :empresa_id
+  AND (:activo IS NULL OR c.es_activo = :activo)
+  AND (:q IS NULL OR (
+        c.nombre LIKE CONCAT('%', :q, '%') OR
+        c.identificacion LIKE CONCAT('%', :q, '%') OR
+        c.email LIKE CONCAT('%', :q, '%') OR
+        c.telefono LIKE CONCAT('%', :q, '%')
+      ))
+ORDER BY c.id DESC
+LIMIT :per OFFSET :off";
+
+        $rows = DB::select($sql, $params);
+
+        $countSql = "SELECT COUNT(1) AS total
+FROM clientes c
+WHERE c.empresa_id = :empresa_id
+  AND (:activo IS NULL OR c.es_activo = :activo)
+  AND (:q IS NULL OR (
+        c.nombre LIKE CONCAT('%', :q, '%') OR
+        c.identificacion LIKE CONCAT('%', :q, '%') OR
+        c.email LIKE CONCAT('%', :q, '%') OR
+        c.telefono LIKE CONCAT('%', :q, '%')
+      ))";
+
+        $total = DB::selectOne($countSql, $params)->total ?? 0;
+
+        return [
+            'data' => array_map(fn($r) => (array) $r, $rows),
+            'pagination' => [
+                'page' => $page,
+                'per_page' => $per,
+                'total' => (int) $total,
+            ],
+        ];
+    }
+
+    public function store(StoreClienteRequest $request)
+    {
+        $data = $request->validated();
+        $data['tipo_id'] = $data['tipo_id'] ?? 'CONSUMIDOR_FINAL';
+        $data['identificacion'] = $data['identificacion'] ?? null;
+        $data['es_activo'] = $data['es_activo'] ?? 1;
+
+        if ($data['tipo_id'] !== 'CONSUMIDOR_FINAL') {
+            if (!$data['identificacion']) {
+                return response()->json([
+                    'error' => 'Validation',
+                    'fields' => ['identificacion' => ['requerido']],
+                ], 422);
+            }
+        }
+
+        if ($data['identificacion']) {
+            $exists = DB::selectOne(
+                "SELECT id FROM clientes WHERE empresa_id = :empresa_id AND identificacion = :identificacion",
+                ['empresa_id' => $data['empresa_id'], 'identificacion' => $data['identificacion']]
+            );
+            if ($exists) {
+                return response()->json([
+                    'error' => 'Conflict',
+                    'message' => 'Duplicado',
+                ], 409);
+            }
+        }
+
+        return DB::transaction(function () use ($data) {
+            DB::insert(
+                "INSERT INTO clientes
+(empresa_id, tipo_id, identificacion, nombre, direccion, telefono, email, es_activo, created_at, updated_at)
+VALUES
+(:empresa_id, :tipo_id, :identificacion, :nombre, :direccion, :telefono, :email, :es_activo, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                $data
+            );
+            $row = DB::selectOne("SELECT * FROM clientes WHERE id = LAST_INSERT_ID()");
+            return ['data' => (array) $row];
+        });
+    }
+
+    public function show(Request $request, $id)
+    {
+        $validator = Validator::make($request->all(), [
+            'empresa_id' => ['required', 'integer'],
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => $validator->errors()->toArray(),
+            ], 422);
+        }
+        $empresa_id = (int) $request->query('empresa_id');
+        $row = DB::selectOne(
+            "SELECT * FROM clientes
+WHERE id = :id AND empresa_id = :empresa_id
+LIMIT 1",
+            ['id' => $id, 'empresa_id' => $empresa_id]
+        );
+        if (!$row) {
+            return response()->json([
+                'error' => 'NotFound',
+                'message' => 'Recurso no encontrado',
+            ], 404);
+        }
+        return ['data' => (array) $row];
+    }
+
+    public function update(UpdateClienteRequest $request, $id)
+    {
+        $data = $request->validated();
+        $data['tipo_id'] = $data['tipo_id'] ?? 'CONSUMIDOR_FINAL';
+        $data['identificacion'] = $data['identificacion'] ?? null;
+        $data['es_activo'] = $data['es_activo'] ?? 1;
+
+        $row = DB::selectOne(
+            "SELECT * FROM clientes WHERE id = :id AND empresa_id = :empresa_id",
+            ['id' => $id, 'empresa_id' => $data['empresa_id']]
+        );
+        if (!$row) {
+            return response()->json([
+                'error' => 'NotFound',
+                'message' => 'Recurso no encontrado',
+            ], 404);
+        }
+
+        if ($data['tipo_id'] !== 'CONSUMIDOR_FINAL' && !$data['identificacion']) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => ['identificacion' => ['requerido']],
+            ], 422);
+        }
+        if ($data['identificacion'] && $data['identificacion'] !== $row->identificacion) {
+            $exists = DB::selectOne(
+                "SELECT id FROM clientes WHERE empresa_id = :empresa_id AND identificacion = :identificacion AND id <> :id",
+                ['empresa_id' => $data['empresa_id'], 'identificacion' => $data['identificacion'], 'id' => $id]
+            );
+            if ($exists) {
+                return response()->json([
+                    'error' => 'Conflict',
+                    'message' => 'Duplicado',
+                ], 409);
+            }
+        }
+
+        DB::update(
+            "UPDATE clientes
+SET tipo_id = :tipo_id,
+    identificacion = :identificacion,
+    nombre = :nombre,
+    direccion = :direccion,
+    telefono = :telefono,
+    email = :email,
+    es_activo = :es_activo,
+    updated_at = CURRENT_TIMESTAMP
+WHERE id = :id AND empresa_id = :empresa_id",
+            [
+                'tipo_id' => $data['tipo_id'],
+                'identificacion' => $data['identificacion'],
+                'nombre' => $data['nombre'],
+                'direccion' => $data['direccion'],
+                'telefono' => $data['telefono'],
+                'email' => $data['email'],
+                'es_activo' => $data['es_activo'],
+                'id' => $id,
+                'empresa_id' => $data['empresa_id'],
+            ]
+        );
+        $row = DB::selectOne(
+            "SELECT * FROM clientes WHERE id = :id AND empresa_id = :empresa_id",
+            ['id' => $id, 'empresa_id' => $data['empresa_id']]
+        );
+        return ['data' => (array) $row];
+    }
+
+    public function destroy(Request $request, $id)
+    {
+        $validator = Validator::make($request->all(), [
+            'empresa_id' => ['required', 'integer'],
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => $validator->errors()->toArray(),
+            ], 422);
+        }
+        $empresa_id = (int) $request->query('empresa_id');
+        $row = DB::selectOne(
+            "SELECT id FROM clientes WHERE id = :id AND empresa_id = :empresa_id",
+            ['id' => $id, 'empresa_id' => $empresa_id]
+        );
+        if (!$row) {
+            return response()->json([
+                'error' => 'NotFound',
+                'message' => 'Recurso no encontrado',
+            ], 404);
+        }
+
+        $refs = DB::selectOne(
+            "SELECT
+  (SELECT COUNT(1) FROM facturas f WHERE f.cliente_id = :id) AS cnt_fact,
+  (SELECT COUNT(1) FROM cxc cx WHERE cx.cliente_id = :id) AS cnt_cxc",
+            ['id' => $id]
+        );
+        if (($refs->cnt_fact ?? 0) > 0 || ($refs->cnt_cxc ?? 0) > 0) {
+            return response()->json([
+                'error' => 'Conflict',
+                'message' => 'Tiene referencias',
+            ], 409);
+        }
+
+        DB::delete(
+            "DELETE FROM clientes WHERE id = :id AND empresa_id = :empresa_id",
+            ['id' => $id, 'empresa_id' => $empresa_id]
+        );
+        return response()->json(null, 204);
+    }
+}

--- a/app/Http/Controllers/ProveedorController.php
+++ b/app/Http/Controllers/ProveedorController.php
@@ -1,0 +1,226 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreProveedorRequest;
+use App\Http\Requests\UpdateProveedorRequest;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+
+class ProveedorController extends Controller
+{
+    public function index(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'empresa_id' => ['required', 'integer'],
+            'q' => ['nullable', 'string'],
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => $validator->errors()->toArray(),
+            ], 422);
+        }
+
+        $page = max((int) $request->query('page', 1), 1);
+        $per = (int) $request->query('per_page', 20);
+        $per = $per > 100 ? 100 : $per;
+        $off = ($page - 1) * $per;
+
+        $empresa_id = (int) $request->query('empresa_id');
+        $q = $request->query('q');
+
+        $params = [
+            'empresa_id' => $empresa_id,
+            'q' => $q,
+            'per' => $per,
+            'off' => $off,
+        ];
+
+        $sql = "SELECT p.*
+FROM proveedores p
+WHERE p.empresa_id = :empresa_id
+  AND (:q IS NULL OR (
+        p.nombre LIKE CONCAT('%', :q, '%') OR
+        p.identificacion LIKE CONCAT('%', :q, '%') OR
+        p.email LIKE CONCAT('%', :q, '%') OR
+        p.telefono LIKE CONCAT('%', :q, '%')
+      ))
+ORDER BY p.id DESC
+LIMIT :per OFFSET :off";
+        $rows = DB::select($sql, $params);
+
+        $countSql = "SELECT COUNT(1) AS total
+FROM proveedores p
+WHERE p.empresa_id = :empresa_id
+  AND (:q IS NULL OR (
+        p.nombre LIKE CONCAT('%', :q, '%') OR
+        p.identificacion LIKE CONCAT('%', :q, '%') OR
+        p.email LIKE CONCAT('%', :q, '%') OR
+        p.telefono LIKE CONCAT('%', :q, '%')
+      ))";
+        $total = DB::selectOne($countSql, $params)->total ?? 0;
+
+        return [
+            'data' => array_map(fn($r) => (array) $r, $rows),
+            'pagination' => [
+                'page' => $page,
+                'per_page' => $per,
+                'total' => (int) $total,
+            ],
+        ];
+    }
+
+    public function store(StoreProveedorRequest $request)
+    {
+        $data = $request->validated();
+
+        $exists = DB::selectOne(
+            "SELECT id FROM proveedores WHERE empresa_id = :empresa_id AND identificacion = :identificacion",
+            ['empresa_id' => $data['empresa_id'], 'identificacion' => $data['identificacion']]
+        );
+        if ($exists) {
+            return response()->json([
+                'error' => 'Conflict',
+                'message' => 'Duplicado',
+            ], 409);
+        }
+
+        return DB::transaction(function () use ($data) {
+            DB::insert(
+                "INSERT INTO proveedores
+(empresa_id, identificacion, nombre, direccion, telefono, email, created_at, updated_at)
+VALUES
+(:empresa_id, :identificacion, :nombre, :direccion, :telefono, :email, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                $data
+            );
+            $row = DB::selectOne("SELECT * FROM proveedores WHERE id = LAST_INSERT_ID()");
+            return ['data' => (array) $row];
+        });
+    }
+
+    public function show(Request $request, $id)
+    {
+        $validator = Validator::make($request->all(), [
+            'empresa_id' => ['required', 'integer'],
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => $validator->errors()->toArray(),
+            ], 422);
+        }
+        $empresa_id = (int) $request->query('empresa_id');
+        $row = DB::selectOne(
+            "SELECT * FROM proveedores
+WHERE id = :id AND empresa_id = :empresa_id
+LIMIT 1",
+            ['id' => $id, 'empresa_id' => $empresa_id]
+        );
+        if (!$row) {
+            return response()->json([
+                'error' => 'NotFound',
+                'message' => 'Recurso no encontrado',
+            ], 404);
+        }
+        return ['data' => (array) $row];
+    }
+
+    public function update(UpdateProveedorRequest $request, $id)
+    {
+        $data = $request->validated();
+
+        $row = DB::selectOne(
+            "SELECT * FROM proveedores WHERE id = :id AND empresa_id = :empresa_id",
+            ['id' => $id, 'empresa_id' => $data['empresa_id']]
+        );
+        if (!$row) {
+            return response()->json([
+                'error' => 'NotFound',
+                'message' => 'Recurso no encontrado',
+            ], 404);
+        }
+
+        if ($data['identificacion'] !== $row->identificacion) {
+            $exists = DB::selectOne(
+                "SELECT id FROM proveedores WHERE empresa_id = :empresa_id AND identificacion = :identificacion AND id <> :id",
+                ['empresa_id' => $data['empresa_id'], 'identificacion' => $data['identificacion'], 'id' => $id]
+            );
+            if ($exists) {
+                return response()->json([
+                    'error' => 'Conflict',
+                    'message' => 'Duplicado',
+                ], 409);
+            }
+        }
+
+        DB::update(
+            "UPDATE proveedores
+SET identificacion = :identificacion,
+    nombre = :nombre,
+    direccion = :direccion,
+    telefono = :telefono,
+    email = :email,
+    updated_at = CURRENT_TIMESTAMP
+WHERE id = :id AND empresa_id = :empresa_id",
+            [
+                'identificacion' => $data['identificacion'],
+                'nombre' => $data['nombre'],
+                'direccion' => $data['direccion'],
+                'telefono' => $data['telefono'],
+                'email' => $data['email'],
+                'id' => $id,
+                'empresa_id' => $data['empresa_id'],
+            ]
+        );
+        $row = DB::selectOne(
+            "SELECT * FROM proveedores WHERE id = :id AND empresa_id = :empresa_id",
+            ['id' => $id, 'empresa_id' => $data['empresa_id']]
+        );
+        return ['data' => (array) $row];
+    }
+
+    public function destroy(Request $request, $id)
+    {
+        $validator = Validator::make($request->all(), [
+            'empresa_id' => ['required', 'integer'],
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => $validator->errors()->toArray(),
+            ], 422);
+        }
+        $empresa_id = (int) $request->query('empresa_id');
+        $row = DB::selectOne(
+            "SELECT id FROM proveedores WHERE id = :id AND empresa_id = :empresa_id",
+            ['id' => $id, 'empresa_id' => $empresa_id]
+        );
+        if (!$row) {
+            return response()->json([
+                'error' => 'NotFound',
+                'message' => 'Recurso no encontrado',
+            ], 404);
+        }
+
+        $refs = DB::selectOne(
+            "SELECT
+  (SELECT COUNT(1) FROM compras c WHERE c.proveedor_id = :id) AS cnt_comp,
+  (SELECT COUNT(1) FROM cxp x WHERE x.proveedor_id = :id) AS cnt_cxp",
+            ['id' => $id]
+        );
+        if (($refs->cnt_comp ?? 0) > 0 || ($refs->cnt_cxp ?? 0) > 0) {
+            return response()->json([
+                'error' => 'Conflict',
+                'message' => 'Tiene referencias',
+            ], 409);
+        }
+
+        DB::delete(
+            "DELETE FROM proveedores WHERE id = :id AND empresa_id = :empresa_id",
+            ['id' => $id, 'empresa_id' => $empresa_id]
+        );
+        return response()->json(null, 204);
+    }
+}

--- a/app/Http/Middleware/CanAny.php
+++ b/app/Http/Middleware/CanAny.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class CanAny
+{
+    public function handle(Request $request, Closure $next, ...$abilities)
+    {
+        $user = $request->user();
+        foreach ($abilities as $ability) {
+            if ($user && $user->can($ability)) {
+                return $next($request);
+            }
+        }
+        abort(403);
+    }
+}

--- a/app/Http/Requests/ApiFormRequest.php
+++ b/app/Http/Requests/ApiFormRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class ApiFormRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    protected function failedValidation(Validator $validator)
+    {
+        throw new HttpResponseException(
+            response()->json([
+                'error' => 'Validation',
+                'fields' => $validator->errors()->toArray(),
+            ], 422)
+        );
+    }
+}

--- a/app/Http/Requests/StoreClienteRequest.php
+++ b/app/Http/Requests/StoreClienteRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests;
+
+class StoreClienteRequest extends ApiFormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'empresa_id' => ['required', 'integer'],
+            'tipo_id' => ['nullable', 'in:CEDULA,RUC,PASAPORTE,CONSUMIDOR_FINAL'],
+            'identificacion' => ['nullable', 'string', 'max:20', 'required_unless:tipo_id,CONSUMIDOR_FINAL'],
+            'nombre' => ['required', 'string', 'max:255'],
+            'direccion' => ['nullable', 'string', 'max:255'],
+            'telefono' => ['nullable', 'string', 'max:100'],
+            'email' => ['nullable', 'email', 'max:255'],
+            'es_activo' => ['boolean'],
+        ];
+    }
+}

--- a/app/Http/Requests/StoreProveedorRequest.php
+++ b/app/Http/Requests/StoreProveedorRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Requests;
+
+class StoreProveedorRequest extends ApiFormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'empresa_id' => ['required', 'integer'],
+            'identificacion' => ['required', 'string', 'max:20'],
+            'nombre' => ['required', 'string', 'max:255'],
+            'direccion' => ['nullable', 'string', 'max:255'],
+            'telefono' => ['nullable', 'string', 'max:100'],
+            'email' => ['nullable', 'email', 'max:255'],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateClienteRequest.php
+++ b/app/Http/Requests/UpdateClienteRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests;
+
+class UpdateClienteRequest extends ApiFormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'empresa_id' => ['required', 'integer'],
+            'tipo_id' => ['required', 'in:CEDULA,RUC,PASAPORTE,CONSUMIDOR_FINAL'],
+            'identificacion' => ['nullable', 'string', 'max:20', 'required_unless:tipo_id,CONSUMIDOR_FINAL'],
+            'nombre' => ['required', 'string', 'max:255'],
+            'direccion' => ['nullable', 'string', 'max:255'],
+            'telefono' => ['nullable', 'string', 'max:100'],
+            'email' => ['nullable', 'email', 'max:255'],
+            'es_activo' => ['boolean'],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateProveedorRequest.php
+++ b/app/Http/Requests/UpdateProveedorRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Requests;
+
+class UpdateProveedorRequest extends ApiFormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'empresa_id' => ['required', 'integer'],
+            'identificacion' => ['required', 'string', 'max:20'],
+            'nombre' => ['required', 'string', 'max:255'],
+            'direccion' => ['nullable', 'string', 'max:255'],
+            'telefono' => ['nullable', 'string', 'max:100'],
+            'email' => ['nullable', 'email', 'max:255'],
+        ];
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -15,6 +15,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->alias([
             'auth.jwt' => \App\Http\Middleware\JwtMiddleware::class,
             'check.subscription' => \App\Http\Middleware\CheckSubscription::class,
+            'can.any' => \App\Http\Middleware\CanAny::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {

--- a/routes/api.php
+++ b/routes/api.php
@@ -14,6 +14,8 @@ use App\Http\Controllers\UnidadMedidaController;
 use App\Http\Controllers\ImpuestoController;
 use App\Http\Controllers\MetodoPagoController;
 use App\Http\Controllers\CategoriaProductoController;
+use App\Http\Controllers\ClienteController;
+use App\Http\Controllers\ProveedorController;
 
 Route::prefix('v1/auth')->group(function () {
     Route::post('/login', [AuthController::class, 'login']);
@@ -90,6 +92,18 @@ Route::prefix('v1')->middleware('auth.jwt')->group(function () {
         Route::get('/categorias/{id}', [CategoriaProductoController::class, 'show'])->middleware('can:productos.crear_editar');
         Route::put('/categorias/{id}', [CategoriaProductoController::class, 'update'])->middleware('can:productos.crear_editar');
         Route::delete('/categorias/{id}', [CategoriaProductoController::class, 'destroy'])->middleware('can:productos.crear_editar');
+
+        Route::get('/clientes', [ClienteController::class, 'index'])->middleware('can:reportes.ver');
+        Route::post('/clientes', [ClienteController::class, 'store'])->middleware('can.any:ventas.facturacion,config.usuarios.gestionar');
+        Route::get('/clientes/{id}', [ClienteController::class, 'show'])->middleware('can:reportes.ver');
+        Route::put('/clientes/{id}', [ClienteController::class, 'update'])->middleware('can.any:ventas.facturacion,config.usuarios.gestionar');
+        Route::delete('/clientes/{id}', [ClienteController::class, 'destroy'])->middleware('can.any:ventas.facturacion,config.usuarios.gestionar');
+
+        Route::get('/proveedores', [ProveedorController::class, 'index'])->middleware('can:proveedores.gestionar');
+        Route::post('/proveedores', [ProveedorController::class, 'store'])->middleware('can:proveedores.gestionar');
+        Route::get('/proveedores/{id}', [ProveedorController::class, 'show'])->middleware('can:proveedores.gestionar');
+        Route::put('/proveedores/{id}', [ProveedorController::class, 'update'])->middleware('can:proveedores.gestionar');
+        Route::delete('/proveedores/{id}', [ProveedorController::class, 'destroy'])->middleware('can:proveedores.gestionar');
     });
 
     Route::get('/estado-suscripcion', SubscriptionStatusController::class);


### PR DESCRIPTION
## Summary
- add v1 REST endpoints for clients with search, pagination and reference-safe deletes
- add v1 REST endpoints for suppliers with uniqueness checks and conflict handling
- support OR-style permission checks via new `can.any` middleware and register routes

## Testing
- `php artisan test` *(fails: require vendor/autoload.php)*
- `composer install` *(fails: requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_6897baa616e8832f911bf59d58cbc9d1