### PR TITLE
feat: add product, recipe and menu endpoints

### DIFF
--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Facades\Cache;
+
+class MenuController extends Controller
+{
+    public function index(Request $request)
+    {
+        $validator = Validator::make($request->query(), [
+            'local_id' => ['required', 'integer'],
+            'categoria_id' => ['nullable', 'integer'],
+            'q' => ['nullable', 'string'],
+            'solo_con_stock' => ['nullable', 'integer'],
+            'page' => ['nullable', 'integer'],
+            'per_page' => ['nullable', 'integer'],
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => $validator->errors()->toArray(),
+            ], 422);
+        }
+        $data = $validator->validated();
+        $page = max((int) ($data['page'] ?? 1), 1);
+        $per = (int) ($data['per_page'] ?? 20);
+        $per = $per > 100 ? 100 : $per;
+        $off = ($page - 1) * $per;
+        $solo = (int) ($data['solo_con_stock'] ?? 0);
+
+        $cacheKey = 'menu:' . md5(json_encode([$data['local_id'], $data['categoria_id'] ?? null, $data['q'] ?? null, $solo, $page, $per]));
+        return Cache::remember($cacheKey, 60, function () use ($data, $per, $off, $page, $solo) {
+            $params = [
+                'local_id' => $data['local_id'],
+                'categoria_id' => $data['categoria_id'] ?? null,
+                'q' => $data['q'] ?? null,
+                'solo_con_stock' => $solo,
+                'per' => $per,
+                'off' => $off,
+            ];
+            $sql = "SELECT
+  p.id, p.codigo, p.nombre, p.descripcion, p.tipo,
+  p.precio_venta, p.impuesto_id,
+  c.nombre AS categoria_nombre,
+  i.codigo AS impuesto_codigo, i.porcentaje AS impuesto_porcentaje,
+  COALESCE((
+    SELECT SUM(s.cantidad)
+    FROM bodegas b
+    JOIN stock s ON s.bodega_id = b.id
+    WHERE b.local_id = :local_id AND s.producto_id = p.id
+  ), 0) AS stock_local
+FROM productos p
+LEFT JOIN categorias_producto c ON c.id = p.categoria_id
+LEFT JOIN impuestos i ON i.id = p.impuesto_id
+JOIN locales l ON l.id = :local_id
+WHERE p.empresa_id = l.empresa_id
+  AND p.deleted_at IS NULL
+  AND p.activo = 1
+  AND p.tipo IN ('BIEN','SERVICIO','MENU')
+  AND (:categoria_id IS NULL OR p.categoria_id = :categoria_id)
+  AND (:q IS NULL OR (p.codigo LIKE CONCAT('%', :q, '%') OR p.nombre LIKE CONCAT('%', :q, '%')))
+  AND (:solo_con_stock = 0 OR COALESCE((
+       SELECT SUM(s2.cantidad)
+       FROM bodegas b2
+       JOIN stock s2 ON s2.bodega_id = b2.id
+       WHERE b2.local_id = :local_id AND s2.producto_id = p.id
+  ), 0) > 0)
+ORDER BY COALESCE(c.orden, 9999) ASC, p.nombre ASC
+LIMIT :per OFFSET :off";
+            $rows = DB::select($sql, $params);
+
+            $countSql = "SELECT COUNT(1) AS total
+FROM productos p
+JOIN locales l ON l.id = :local_id
+WHERE p.empresa_id = l.empresa_id
+  AND p.deleted_at IS NULL
+  AND p.activo = 1
+  AND p.tipo IN ('BIEN','SERVICIO','MENU')
+  AND (:categoria_id IS NULL OR p.categoria_id = :categoria_id)
+  AND (:q IS NULL OR (p.codigo LIKE CONCAT('%', :q, '%') OR p.nombre LIKE CONCAT('%', :q, '%')))
+  AND (:solo_con_stock = 0 OR COALESCE((
+       SELECT SUM(s2.cantidad)
+       FROM bodegas b2
+       JOIN stock s2 ON s2.bodega_id = b2.id
+       WHERE b2.local_id = :local_id AND s2.producto_id = p.id
+  ), 0) > 0)";
+            $total = DB::selectOne($countSql, $params)->total ?? 0;
+
+            return [
+                'data' => array_map(fn($r) => (array) $r, $rows),
+                'pagination' => [
+                    'page' => $page,
+                    'per_page' => $per,
+                    'total' => (int) $total,
+                ],
+            ];
+        });
+    }
+}

--- a/app/Http/Controllers/ProductoController.php
+++ b/app/Http/Controllers/ProductoController.php
@@ -1,0 +1,405 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+
+class ProductoController extends Controller
+{
+    public function index(Request $request)
+    {
+        $validator = Validator::make($request->query(), [
+            'empresa_id' => ['required', 'integer'],
+            'categoria_id' => ['nullable', 'integer'],
+            'tipo' => ['nullable'],
+            'activo' => ['nullable', 'integer'],
+            'q' => ['nullable', 'string'],
+            'page' => ['nullable', 'integer'],
+            'per_page' => ['nullable', 'integer'],
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => $validator->errors()->toArray(),
+            ], 422);
+        }
+
+        $data = $validator->validated();
+        $page = max((int) ($data['page'] ?? 1), 1);
+        $per = (int) ($data['per_page'] ?? 20);
+        $per = $per > 100 ? 100 : $per;
+        $off = ($page - 1) * $per;
+
+        $params = [
+            'empresa_id' => $data['empresa_id'],
+            'categoria_id' => $data['categoria_id'] ?? null,
+            'tipo' => $data['tipo'] ?? null,
+            'activo' => $data['activo'] ?? null,
+            'q' => $data['q'] ?? null,
+            'per' => $per,
+            'off' => $off,
+        ];
+
+        $sql = "SELECT
+  p.id, p.empresa_id, p.categoria_id, p.codigo, p.nombre, p.descripcion,
+  p.tipo, p.sku, p.unidad_id, p.impuesto_id, p.precio_venta, p.costo_promedio,
+  p.es_receta, p.activo, p.created_at, p.updated_at,
+  c.nombre AS categoria_nombre,
+  um.abreviatura AS unidad,
+  i.codigo AS impuesto_codigo, i.porcentaje AS impuesto_porcentaje
+FROM productos p
+LEFT JOIN categorias_producto c ON c.id = p.categoria_id
+LEFT JOIN unidades_medida um ON um.id = p.unidad_id
+LEFT JOIN impuestos i ON i.id = p.impuesto_id
+WHERE p.empresa_id = :empresa_id
+  AND p.deleted_at IS NULL
+  AND (:categoria_id IS NULL OR p.categoria_id = :categoria_id)
+  AND (:tipo IS NULL OR p.tipo = :tipo)
+  AND (:activo IS NULL OR p.activo = :activo)
+  AND (:q IS NULL OR (
+       p.codigo LIKE CONCAT('%', :q, '%') OR
+       p.nombre LIKE CONCAT('%', :q, '%') OR
+       p.sku LIKE CONCAT('%', :q, '%')
+  ))
+ORDER BY p.id DESC
+LIMIT :per OFFSET :off";
+
+        $rows = DB::select($sql, $params);
+
+        $countSql = "SELECT COUNT(1) AS total
+FROM productos p
+WHERE p.empresa_id = :empresa_id
+  AND p.deleted_at IS NULL
+  AND (:categoria_id IS NULL OR p.categoria_id = :categoria_id)
+  AND (:tipo IS NULL OR p.tipo = :tipo)
+  AND (:activo IS NULL OR p.activo = :activo)
+  AND (:q IS NULL OR (
+       p.codigo LIKE CONCAT('%', :q, '%') OR
+       p.nombre LIKE CONCAT('%', :q, '%') OR
+       p.sku LIKE CONCAT('%', :q, '%')
+  ))";
+
+        $total = DB::selectOne($countSql, $params)->total ?? 0;
+
+        return [
+            'data' => array_map(fn($r) => (array) $r, $rows),
+            'pagination' => [
+                'page' => $page,
+                'per_page' => $per,
+                'total' => (int) $total,
+            ],
+        ];
+    }
+
+    public function store(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'empresa_id' => ['required', 'integer'],
+            'categoria_id' => ['nullable', 'integer'],
+            'codigo' => ['required'],
+            'nombre' => ['required'],
+            'descripcion' => ['nullable'],
+            'tipo' => ['required', 'in:BIEN,SERVICIO,INSUMO,MENU'],
+            'sku' => ['nullable'],
+            'unidad_id' => ['nullable', 'integer'],
+            'impuesto_id' => ['nullable', 'integer'],
+            'precio_venta' => ['numeric', 'min:0'],
+            'costo_promedio' => ['numeric', 'min:0'],
+            'es_receta' => ['boolean'],
+            'activo' => ['boolean'],
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => $validator->errors()->toArray(),
+            ], 422);
+        }
+
+        $data = $validator->validated();
+
+        $exists = DB::selectOne(
+            "SELECT id FROM productos WHERE empresa_id = :empresa_id AND codigo = :codigo AND deleted_at IS NULL",
+            ['empresa_id' => $data['empresa_id'], 'codigo' => $data['codigo']]
+        );
+        if ($exists) {
+            return response()->json([
+                'error' => 'Conflict',
+                'message' => 'Duplicado',
+            ], 409);
+        }
+
+        if (isset($data['categoria_id'])) {
+            $cat = DB::selectOne(
+                "SELECT id FROM categorias_producto WHERE id = :id AND empresa_id = :empresa_id",
+                ['id' => $data['categoria_id'], 'empresa_id' => $data['empresa_id']]
+            );
+            if (!$cat) {
+                return response()->json([
+                    'error' => 'Validation',
+                    'fields' => ['categoria_id' => ['No existe']],
+                ], 422);
+            }
+        }
+        if (isset($data['unidad_id'])) {
+            $um = DB::selectOne(
+                "SELECT id FROM unidades_medida WHERE id = :id AND (empresa_id = :empresa_id OR empresa_id IS NULL)",
+                ['id' => $data['unidad_id'], 'empresa_id' => $data['empresa_id']]
+            );
+            if (!$um) {
+                return response()->json([
+                    'error' => 'Validation',
+                    'fields' => ['unidad_id' => ['No existe']],
+                ], 422);
+            }
+        }
+        if (isset($data['impuesto_id'])) {
+            $imp = DB::selectOne(
+                "SELECT id FROM impuestos WHERE id = :id AND (empresa_id = :empresa_id OR empresa_id IS NULL)",
+                ['id' => $data['impuesto_id'], 'empresa_id' => $data['empresa_id']]
+            );
+            if (!$imp) {
+                return response()->json([
+                    'error' => 'Validation',
+                    'fields' => ['impuesto_id' => ['No existe']],
+                ], 422);
+            }
+        }
+
+        return DB::transaction(function () use ($data) {
+            DB::insert(
+                "INSERT INTO productos
+(empresa_id, categoria_id, codigo, nombre, descripcion, tipo, sku, unidad_id, impuesto_id,
+ precio_venta, costo_promedio, es_receta, activo, created_at, updated_at)
+VALUES
+(:empresa_id, :categoria_id, :codigo, :nombre, :descripcion, :tipo, :sku, :unidad_id, :impuesto_id,
+ :precio_venta, :costo_promedio, :es_receta, :activo, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                [
+                    'empresa_id' => $data['empresa_id'],
+                    'categoria_id' => $data['categoria_id'] ?? null,
+                    'codigo' => $data['codigo'],
+                    'nombre' => $data['nombre'],
+                    'descripcion' => $data['descripcion'] ?? null,
+                    'tipo' => $data['tipo'],
+                    'sku' => $data['sku'] ?? null,
+                    'unidad_id' => $data['unidad_id'] ?? null,
+                    'impuesto_id' => $data['impuesto_id'] ?? null,
+                    'precio_venta' => $data['precio_venta'] ?? 0,
+                    'costo_promedio' => $data['costo_promedio'] ?? 0,
+                    'es_receta' => $data['es_receta'] ?? 0,
+                    'activo' => $data['activo'] ?? 1,
+                ]
+            );
+            $row = DB::selectOne("SELECT * FROM productos WHERE id = LAST_INSERT_ID()");
+            return ['data' => (array) $row];
+        });
+    }
+
+    public function show(Request $request, $id)
+    {
+        $validator = Validator::make($request->query(), [
+            'empresa_id' => ['required', 'integer'],
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => $validator->errors()->toArray(),
+            ], 422);
+        }
+        $empresa_id = $validator->validated()['empresa_id'];
+        $row = DB::selectOne(
+            "SELECT
+  p.*, c.nombre AS categoria_nombre, um.abreviatura AS unidad,
+  i.codigo AS impuesto_codigo, i.porcentaje AS impuesto_porcentaje
+FROM productos p
+LEFT JOIN categorias_producto c ON c.id = p.categoria_id
+LEFT JOIN unidades_medida um ON um.id = p.unidad_id
+LEFT JOIN impuestos i ON i.id = p.impuesto_id
+WHERE p.id = :id AND p.empresa_id = :empresa_id AND p.deleted_at IS NULL
+LIMIT 1",
+            ['id' => $id, 'empresa_id' => $empresa_id]
+        );
+        if (!$row) {
+            return response()->json([
+                'error' => 'NotFound',
+                'message' => 'Recurso no encontrado',
+            ], 404);
+        }
+        return ['data' => (array) $row];
+    }
+
+    public function update(Request $request, $id)
+    {
+        $validator = Validator::make($request->all(), [
+            'empresa_id' => ['required', 'integer'],
+            'categoria_id' => ['nullable', 'integer'],
+            'codigo' => ['required'],
+            'nombre' => ['required'],
+            'descripcion' => ['nullable'],
+            'tipo' => ['required', 'in:BIEN,SERVICIO,INSUMO,MENU'],
+            'sku' => ['nullable'],
+            'unidad_id' => ['nullable', 'integer'],
+            'impuesto_id' => ['nullable', 'integer'],
+            'precio_venta' => ['numeric', 'min:0'],
+            'costo_promedio' => ['numeric', 'min:0'],
+            'es_receta' => ['boolean'],
+            'activo' => ['boolean'],
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => $validator->errors()->toArray(),
+            ], 422);
+        }
+        $data = $validator->validated();
+
+        $row = DB::selectOne(
+            "SELECT * FROM productos WHERE id = :id AND empresa_id = :empresa_id AND deleted_at IS NULL",
+            ['id' => $id, 'empresa_id' => $data['empresa_id']]
+        );
+        if (!$row) {
+            return response()->json([
+                'error' => 'NotFound',
+                'message' => 'Recurso no encontrado',
+            ], 404);
+        }
+        if ($data['codigo'] !== $row->codigo) {
+            $exists = DB::selectOne(
+                "SELECT id FROM productos WHERE empresa_id = :empresa_id AND codigo = :codigo AND id <> :id AND deleted_at IS NULL",
+                ['empresa_id' => $data['empresa_id'], 'codigo' => $data['codigo'], 'id' => $id]
+            );
+            if ($exists) {
+                return response()->json([
+                    'error' => 'Conflict',
+                    'message' => 'Duplicado',
+                ], 409);
+            }
+        }
+        if (isset($data['categoria_id'])) {
+            $cat = DB::selectOne(
+                "SELECT id FROM categorias_producto WHERE id = :id AND empresa_id = :empresa_id",
+                ['id' => $data['categoria_id'], 'empresa_id' => $data['empresa_id']]
+            );
+            if (!$cat) {
+                return response()->json([
+                    'error' => 'Validation',
+                    'fields' => ['categoria_id' => ['No existe']],
+                ], 422);
+            }
+        }
+        if (isset($data['unidad_id'])) {
+            $um = DB::selectOne(
+                "SELECT id FROM unidades_medida WHERE id = :id AND (empresa_id = :empresa_id OR empresa_id IS NULL)",
+                ['id' => $data['unidad_id'], 'empresa_id' => $data['empresa_id']]
+            );
+            if (!$um) {
+                return response()->json([
+                    'error' => 'Validation',
+                    'fields' => ['unidad_id' => ['No existe']],
+                ], 422);
+            }
+        }
+        if (isset($data['impuesto_id'])) {
+            $imp = DB::selectOne(
+                "SELECT id FROM impuestos WHERE id = :id AND (empresa_id = :empresa_id OR empresa_id IS NULL)",
+                ['id' => $data['impuesto_id'], 'empresa_id' => $data['empresa_id']]
+            );
+            if (!$imp) {
+                return response()->json([
+                    'error' => 'Validation',
+                    'fields' => ['impuesto_id' => ['No existe']],
+                ], 422);
+            }
+        }
+
+        DB::update(
+            "UPDATE productos
+SET categoria_id   = :categoria_id,
+    codigo         = :codigo,
+    nombre         = :nombre,
+    descripcion    = :descripcion,
+    tipo           = :tipo,
+    sku            = :sku,
+    unidad_id      = :unidad_id,
+    impuesto_id    = :impuesto_id,
+    precio_venta   = :precio_venta,
+    costo_promedio = :costo_promedio,
+    es_receta      = :es_receta,
+    activo         = :activo,
+    updated_at     = CURRENT_TIMESTAMP
+WHERE id = :id AND empresa_id = :empresa_id AND deleted_at IS NULL",
+            [
+                'categoria_id' => $data['categoria_id'] ?? null,
+                'codigo' => $data['codigo'],
+                'nombre' => $data['nombre'],
+                'descripcion' => $data['descripcion'] ?? null,
+                'tipo' => $data['tipo'],
+                'sku' => $data['sku'] ?? null,
+                'unidad_id' => $data['unidad_id'] ?? null,
+                'impuesto_id' => $data['impuesto_id'] ?? null,
+                'precio_venta' => $data['precio_venta'] ?? 0,
+                'costo_promedio' => $data['costo_promedio'] ?? 0,
+                'es_receta' => $data['es_receta'] ?? 0,
+                'activo' => $data['activo'] ?? 1,
+                'id' => $id,
+                'empresa_id' => $data['empresa_id'],
+            ]
+        );
+
+        $row = DB::selectOne("SELECT * FROM productos WHERE id = :id AND empresa_id = :empresa_id", ['id' => $id, 'empresa_id' => $data['empresa_id']]);
+        return ['data' => (array) $row];
+    }
+
+    public function destroy(Request $request, $id)
+    {
+        $validator = Validator::make($request->query(), [
+            'empresa_id' => ['required', 'integer'],
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => $validator->errors()->toArray(),
+            ], 422);
+        }
+        $empresa_id = $validator->validated()['empresa_id'];
+        $row = DB::selectOne(
+            "SELECT id FROM productos WHERE id = :id AND empresa_id = :empresa_id AND deleted_at IS NULL",
+            ['id' => $id, 'empresa_id' => $empresa_id]
+        );
+        if (!$row) {
+            return response()->json([
+                'error' => 'NotFound',
+                'message' => 'Recurso no encontrado',
+            ], 404);
+        }
+
+        $ref = DB::selectOne(
+            "SELECT
+  (SELECT COUNT(1) FROM recetas r WHERE r.producto_id = :id OR r.insumo_id = :id) AS cnt_rec,
+  (SELECT COUNT(1) FROM pedidos_det pd WHERE pd.producto_id = :id) AS cnt_ped,
+  (SELECT COUNT(1) FROM facturas_det fd WHERE fd.producto_id = :id) AS cnt_fac,
+  (SELECT COUNT(1) FROM compras_det cd  WHERE cd.producto_id = :id) AS cnt_comp,
+  (SELECT COUNT(1) FROM stock s WHERE s.producto_id = :id) AS cnt_stock",
+            ['id' => $id]
+        );
+        if ($ref->cnt_rec > 0 || $ref->cnt_ped > 0 || $ref->cnt_fac > 0 || $ref->cnt_comp > 0 || $ref->cnt_stock > 0) {
+            return response()->json([
+                'error' => 'Conflict',
+                'message' => 'Tiene referencias',
+            ], 409);
+        }
+
+        DB::update(
+            "UPDATE productos
+SET deleted_at = CURRENT_TIMESTAMP,
+    updated_at = CURRENT_TIMESTAMP
+WHERE id = :id AND empresa_id = :empresa_id AND deleted_at IS NULL",
+            ['id' => $id, 'empresa_id' => $empresa_id]
+        );
+
+        return response()->json(null, 204);
+    }
+}

--- a/app/Http/Controllers/ProductoImportController.php
+++ b/app/Http/Controllers/ProductoImportController.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+
+class ProductoImportController extends Controller
+{
+    public function store(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'empresa_id' => ['required', 'integer'],
+            'file' => ['required', 'file'],
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => $validator->errors()->toArray(),
+            ], 422);
+        }
+        $empresa_id = $validator->validated()['empresa_id'];
+        $file = $request->file('file');
+        $path = $file->getRealPath();
+
+        $handle = fopen($path, 'r');
+        if (!$handle) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => ['file' => ['No se pudo leer']],
+            ], 422);
+        }
+        $header = fgetcsv($handle);
+        $columns = array_map(fn($h) => strtolower(trim($h)), $header);
+
+        $inserted = 0;
+        $updated = 0;
+        $errors = [];
+        $seen = [];
+        $rowNum = 1;
+        while (($row = fgetcsv($handle)) !== false) {
+            $rowNum++;
+            $data = [];
+            foreach ($columns as $i => $col) {
+                $data[$col] = trim($row[$i] ?? '');
+            }
+            $codigo = strtoupper($data['codigo'] ?? '');
+            $nombre = $data['nombre'] ?? '';
+            if ($codigo === '' || $nombre === '') {
+                $errors[] = ['row' => $rowNum, 'msg' => 'codigo/nombre requerido'];
+                continue;
+            }
+            if (isset($seen[$codigo])) {
+                $errors[] = ['row' => $rowNum, 'msg' => 'codigo duplicado en archivo'];
+                continue;
+            }
+            $seen[$codigo] = true;
+            $tipo = $data['tipo'] ? strtoupper($data['tipo']) : 'BIEN';
+            $precio = is_numeric($data['precio_venta'] ?? null) ? (float)$data['precio_venta'] : 0;
+            $activo = ($data['activo'] ?? '1') != '0' ? 1 : 0;
+            $sku = $data['sku'] ?? null;
+            $descripcion = $data['descripcion'] ?? null;
+            $categoria_nombre = $data['categoria_nombre'] ?? null;
+            $unidad_abrev = isset($data['unidad_abrev']) ? strtoupper($data['unidad_abrev']) : null;
+            $impuesto_codigo = isset($data['impuesto_codigo']) ? strtoupper($data['impuesto_codigo']) : null;
+
+            $categoria_id = null;
+            if ($categoria_nombre) {
+                $categoria = DB::selectOne("SELECT id FROM categorias_producto WHERE empresa_id = :empresa_id AND nombre = :nombre", ['empresa_id' => $empresa_id, 'nombre' => $categoria_nombre]);
+                if (!$categoria) {
+                    DB::insert("INSERT INTO categorias_producto (empresa_id, nombre, created_at, updated_at) VALUES (:empresa_id,:nombre,CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)", ['empresa_id'=>$empresa_id,'nombre'=>$categoria_nombre]);
+                    $categoria_id = DB::selectOne("SELECT LAST_INSERT_ID() AS id")->id;
+                } else {
+                    $categoria_id = $categoria->id;
+                }
+            }
+            $unidad_id = null;
+            if ($unidad_abrev) {
+                $um = DB::selectOne("SELECT id FROM unidades_medida WHERE abreviatura = :abrev AND (empresa_id = :empresa_id OR empresa_id IS NULL)", ['abrev'=>$unidad_abrev,'empresa_id'=>$empresa_id]);
+                $unidad_id = $um->id ?? null;
+            }
+            $impuesto_id = null;
+            if ($impuesto_codigo) {
+                $imp = DB::selectOne("SELECT id FROM impuestos WHERE (empresa_id = :empresa_id OR empresa_id IS NULL) AND codigo = :codigo ORDER BY empresa_id DESC LIMIT 1", ['empresa_id'=>$empresa_id,'codigo'=>$impuesto_codigo]);
+                $impuesto_id = $imp->id ?? null;
+            }
+
+            $exists = DB::selectOne("SELECT id FROM productos WHERE empresa_id = :empresa_id AND codigo = :codigo", ['empresa_id'=>$empresa_id,'codigo'=>$codigo]);
+            DB::insert("INSERT INTO productos (empresa_id, categoria_id, codigo, nombre, descripcion, tipo, sku, unidad_id, impuesto_id, precio_venta, costo_promedio, es_receta, activo, created_at, updated_at)
+VALUES (:empresa_id, :categoria_id, :codigo, :nombre, :descripcion, :tipo, :sku, :unidad_id, :impuesto_id, :precio_venta, 0, 0, :activo, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+ON DUPLICATE KEY UPDATE
+  categoria_id=VALUES(categoria_id), nombre=VALUES(nombre), descripcion=VALUES(descripcion), tipo=VALUES(tipo), sku=VALUES(sku), unidad_id=VALUES(unidad_id), impuesto_id=VALUES(impuesto_id), precio_venta=VALUES(precio_venta), costo_promedio=VALUES(costo_promedio), es_receta=VALUES(es_receta), activo=VALUES(activo), updated_at=CURRENT_TIMESTAMP", [
+                'empresa_id'=>$empresa_id,
+                'categoria_id'=>$categoria_id,
+                'codigo'=>$codigo,
+                'nombre'=>$nombre,
+                'descripcion'=>$descripcion,
+                'tipo'=>$tipo,
+                'sku'=>$sku,
+                'unidad_id'=>$unidad_id,
+                'impuesto_id'=>$impuesto_id,
+                'precio_venta'=>$precio,
+                'activo'=>$activo,
+            ]);
+            if ($exists) {
+                $updated++;
+            } else {
+                $inserted++;
+            }
+        }
+        fclose($handle);
+
+        return [
+            'inserted' => $inserted,
+            'updated' => $updated,
+            'errors' => $errors,
+        ];
+    }
+}

--- a/app/Http/Controllers/RecetaController.php
+++ b/app/Http/Controllers/RecetaController.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+
+class RecetaController extends Controller
+{
+    public function index(Request $request, $producto_id)
+    {
+        $validator = Validator::make($request->query(), [
+            'empresa_id' => ['required', 'integer'],
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => $validator->errors()->toArray(),
+            ], 422);
+        }
+        $empresa_id = $validator->validated()['empresa_id'];
+        $prod = DB::selectOne(
+            "SELECT id FROM productos WHERE id = :id AND empresa_id = :empresa_id AND deleted_at IS NULL",
+            ['id' => $producto_id, 'empresa_id' => $empresa_id]
+        );
+        if (!$prod) {
+            return response()->json([
+                'error' => 'NotFound',
+                'message' => 'Recurso no encontrado',
+            ], 404);
+        }
+        $rows = DB::select(
+            "SELECT
+  r.insumo_id, p.codigo AS insumo_codigo, p.nombre AS insumo_nombre,
+  r.cantidad, r.merma_porcentaje, p.unidad_id, um.abreviatura AS unidad
+FROM recetas r
+JOIN productos p ON p.id = r.insumo_id
+LEFT JOIN unidades_medida um ON um.id = p.unidad_id
+WHERE r.producto_id = :producto_id
+ORDER BY p.nombre ASC",
+            ['producto_id' => $producto_id]
+        );
+        return ['data' => array_map(fn($r) => (array) $r, $rows)];
+    }
+
+    public function store(Request $request, $producto_id)
+    {
+        $validator = Validator::make($request->all(), [
+            'empresa_id' => ['required', 'integer'],
+            '*.insumo_id' => ['required', 'integer'],
+            '*.cantidad' => ['required', 'numeric'],
+            '*.merma_porcentaje' => ['nullable', 'numeric'],
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => $validator->errors()->toArray(),
+            ], 422);
+        }
+        $empresa_id = $validator->validated()['empresa_id'];
+        $lines = $request->all();
+        unset($lines['empresa_id']);
+
+        $prod = DB::selectOne("SELECT id, es_receta FROM productos WHERE id = :id AND empresa_id = :empresa_id AND deleted_at IS NULL", ['id'=>$producto_id,'empresa_id'=>$empresa_id]);
+        if (!$prod) {
+            return response()->json([
+                'error' => 'NotFound',
+                'message' => 'Recurso no encontrado',
+            ], 404);
+        }
+
+        foreach ($lines as $idx => $line) {
+            if ($line['insumo_id'] == $producto_id) {
+                return response()->json([
+                    'error' => 'Validation',
+                    'fields' => ["$idx.insumo_id" => ['No puede ser el mismo producto']],
+                ], 422);
+            }
+            $ins = DB::selectOne("SELECT id FROM productos WHERE id = :id AND empresa_id = :empresa_id AND deleted_at IS NULL", ['id'=>$line['insumo_id'],'empresa_id'=>$empresa_id]);
+            if (!$ins) {
+                return response()->json([
+                    'error' => 'Validation',
+                    'fields' => ["$idx.insumo_id" => ['No existe']],
+                ], 422);
+            }
+        }
+
+        return DB::transaction(function () use ($lines, $producto_id) {
+            DB::delete("DELETE FROM recetas WHERE producto_id = :producto_id", ['producto_id' => $producto_id]);
+            foreach ($lines as $line) {
+                DB::insert(
+                    "INSERT INTO recetas (producto_id, insumo_id, cantidad, merma_porcentaje)
+VALUES (:producto_id, :insumo_id, :cantidad, :merma)",
+                    [
+                        'producto_id' => $producto_id,
+                        'insumo_id' => $line['insumo_id'],
+                        'cantidad' => $line['cantidad'],
+                        'merma' => $line['merma_porcentaje'] ?? 0,
+                    ]
+                );
+            }
+            $rows = DB::select(
+                "SELECT
+  r.insumo_id, p.codigo AS insumo_codigo, p.nombre AS insumo_nombre,
+  r.cantidad, r.merma_porcentaje, p.unidad_id, um.abreviatura AS unidad
+FROM recetas r
+JOIN productos p ON p.id = r.insumo_id
+LEFT JOIN unidades_medida um ON um.id = p.unidad_id
+WHERE r.producto_id = :producto_id
+ORDER BY p.nombre ASC",
+                ['producto_id' => $producto_id]
+            );
+            return ['data' => array_map(fn($r) => (array) $r, $rows)];
+        });
+    }
+
+    public function destroy(Request $request, $producto_id, $insumo_id)
+    {
+        $validator = Validator::make($request->query(), [
+            'empresa_id' => ['required', 'integer'],
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => $validator->errors()->toArray(),
+            ], 422);
+        }
+        $empresa_id = $validator->validated()['empresa_id'];
+        $prod = DB::selectOne("SELECT id FROM productos WHERE id = :id AND empresa_id = :empresa_id AND deleted_at IS NULL", ['id'=>$producto_id,'empresa_id'=>$empresa_id]);
+        if (!$prod) {
+            return response()->json([
+                'error' => 'NotFound',
+                'message' => 'Recurso no encontrado',
+            ], 404);
+        }
+        DB::delete("DELETE FROM recetas WHERE producto_id = :producto_id AND insumo_id = :insumo_id", ['producto_id'=>$producto_id,'insumo_id'=>$insumo_id]);
+        $rows = DB::select(
+            "SELECT r.insumo_id, p.codigo AS insumo_codigo, p.nombre AS insumo_nombre,
+       r.cantidad, r.merma_porcentaje
+FROM recetas r
+JOIN productos p ON p.id = r.insumo_id
+WHERE r.producto_id = :producto_id
+ORDER BY p.nombre ASC",
+            ['producto_id' => $producto_id]
+        );
+        return ['data' => array_map(fn($r) => (array) $r, $rows)];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,6 +16,10 @@ use App\Http\Controllers\MetodoPagoController;
 use App\Http\Controllers\CategoriaProductoController;
 use App\Http\Controllers\ClienteController;
 use App\Http\Controllers\ProveedorController;
+use App\Http\Controllers\ProductoController;
+use App\Http\Controllers\RecetaController;
+use App\Http\Controllers\ProductoImportController;
+use App\Http\Controllers\MenuController;
 
 Route::prefix('v1/auth')->group(function () {
     Route::post('/login', [AuthController::class, 'login']);
@@ -25,6 +29,8 @@ Route::prefix('v1/auth')->group(function () {
     Route::post('/change-password', [AuthController::class, 'changePassword'])->middleware('auth.jwt');
     Route::post('/force-invalidate', [AuthController::class, 'forceInvalidate'])->middleware('auth.jwt');
 });
+
+Route::get('/v1/menu', [MenuController::class, 'index']);
 
 Route::prefix('v1')->middleware('auth.jwt')->group(function () {
     Route::middleware('check.subscription')->group(function () {
@@ -92,6 +98,18 @@ Route::prefix('v1')->middleware('auth.jwt')->group(function () {
         Route::get('/categorias/{id}', [CategoriaProductoController::class, 'show'])->middleware('can:productos.crear_editar');
         Route::put('/categorias/{id}', [CategoriaProductoController::class, 'update'])->middleware('can:productos.crear_editar');
         Route::delete('/categorias/{id}', [CategoriaProductoController::class, 'destroy'])->middleware('can:productos.crear_editar');
+
+        Route::get('/productos', [ProductoController::class, 'index'])->middleware('can:productos.ver');
+        Route::post('/productos', [ProductoController::class, 'store'])->middleware('can:productos.crear_editar');
+        Route::get('/productos/{id}', [ProductoController::class, 'show'])->middleware('can:productos.ver');
+        Route::put('/productos/{id}', [ProductoController::class, 'update'])->middleware('can:productos.crear_editar');
+        Route::delete('/productos/{id}', [ProductoController::class, 'destroy'])->middleware('can:productos.crear_editar');
+
+        Route::get('/productos/{id}/receta', [RecetaController::class, 'index'])->middleware('can:productos.crear_editar');
+        Route::post('/productos/{id}/receta', [RecetaController::class, 'store'])->middleware('can:productos.crear_editar');
+        Route::delete('/productos/{id}/receta/{insumo_id}', [RecetaController::class, 'destroy'])->middleware('can:productos.crear_editar');
+
+        Route::post('/productos/import', [ProductoImportController::class, 'store'])->middleware('can:productos.crear_editar');
 
         Route::get('/clientes', [ClienteController::class, 'index'])->middleware('can:reportes.ver');
         Route::post('/clientes', [ClienteController::class, 'store'])->middleware('can.any:ventas.facturacion,config.usuarios.gestionar');


### PR DESCRIPTION
## Summary
- add CRUD endpoints for productos with validation and soft delete
- support recetas BOM operations and bulk import
- expose cached public menu endpoint

## Testing
- `phpunit` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6897bd0779fc832f84e31158c198117d