### PR TITLE
feat: add basic bodegas management

### DIFF
--- a/app/Http/Controllers/BodegaController.php
+++ b/app/Http/Controllers/BodegaController.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreBodegaRequest;
+use App\Http\Requests\UpdateBodegaRequest;
+use App\Http\Resources\BodegaCollection;
+use App\Http\Resources\BodegaResource;
+use App\Models\Bodega;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class BodegaController extends Controller
+{
+    public function index(Request $request)
+    {
+        $query = Bodega::query();
+
+        if ($q = $request->query('q')) {
+            $query->where(function ($q2) use ($q) {
+                $q2->where('codigo', 'like', "%$q%")
+                    ->orWhere('nombre', 'like', "%$q%");
+            });
+        }
+
+        if ($estado = $request->query('estado')) {
+            $query->where('estado', $estado);
+        }
+
+        if ($sort = $request->query('sort')) {
+            foreach (explode(',', $sort) as $part) {
+                $direction = 'asc';
+                $column = $part;
+                if (str_starts_with($part, '-')) {
+                    $direction = 'desc';
+                    $column = substr($part, 1);
+                }
+                if (in_array($column, ['codigo', 'nombre'])) {
+                    $query->orderBy($column, $direction);
+                }
+            }
+        }
+
+        $perPage = min($request->query('per_page', 20), 100);
+        $bodegas = $query->paginate($perPage);
+
+        return new BodegaCollection($bodegas);
+    }
+
+    public function store(StoreBodegaRequest $request)
+    {
+        $bodega = Bodega::create($request->validated());
+        return (new BodegaResource($bodega))->response()->setStatusCode(201);
+    }
+
+    public function show($id)
+    {
+        $bodega = Bodega::find($id);
+        if (!$bodega) {
+            return response()->json([
+                'error' => 'NotFound',
+                'message' => 'Recurso no encontrado',
+            ], 404);
+        }
+        return new BodegaResource($bodega);
+    }
+
+    public function update(UpdateBodegaRequest $request, $id)
+    {
+        $bodega = Bodega::find($id);
+        if (!$bodega) {
+            return response()->json([
+                'error' => 'NotFound',
+                'message' => 'Recurso no encontrado',
+            ], 404);
+        }
+        $bodega->update($request->validated());
+        return new BodegaResource($bodega);
+    }
+
+    public function destroy($id)
+    {
+        $bodega = Bodega::find($id);
+        if (!$bodega) {
+            return response()->json([
+                'error' => 'NotFound',
+                'message' => 'Recurso no encontrado',
+            ], 404);
+        }
+
+        $saldos = DB::table('inventario_saldos')
+            ->where('bodega_id', $id)
+            ->where('cantidad', '<>', 0)
+            ->count();
+        if ($saldos > 0) {
+            return response()->json([
+                'error' => 'Conflict',
+                'message' => 'La bodega posee saldos',
+            ], 409);
+        }
+
+        $bodega->delete();
+        return response()->json(null, 204);
+    }
+}

--- a/app/Http/Requests/StoreBodegaRequest.php
+++ b/app/Http/Requests/StoreBodegaRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreBodegaRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'codigo' => ['required', 'string', 'max:50', 'unique:bodegas,codigo'],
+            'nombre' => ['required', 'string', 'max:255'],
+            'estado' => ['required', 'in:activa,inactiva'],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateBodegaRequest.php
+++ b/app/Http/Requests/UpdateBodegaRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateBodegaRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        $id = $this->route('id');
+        return [
+            'codigo' => ['required', 'string', 'max:50', Rule::unique('bodegas', 'codigo')->ignore($id)],
+            'nombre' => ['required', 'string', 'max:255'],
+            'estado' => ['required', 'in:activa,inactiva'],
+        ];
+    }
+}

--- a/app/Http/Resources/BodegaCollection.php
+++ b/app/Http/Resources/BodegaCollection.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class BodegaCollection extends ResourceCollection
+{
+    public function toArray($request): array
+    {
+        return [
+            'data' => BodegaResource::collection($this->collection),
+            'pagination' => [
+                'current_page' => $this->currentPage(),
+                'per_page' => $this->perPage(),
+                'total' => $this->total(),
+            ],
+        ];
+    }
+}

--- a/app/Http/Resources/BodegaResource.php
+++ b/app/Http/Resources/BodegaResource.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin \App\Models\Bodega */
+class BodegaResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'codigo' => $this->codigo,
+            'nombre' => $this->nombre,
+            'estado' => $this->estado,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/app/Models/Bodega.php
+++ b/app/Models/Bodega.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Bodega extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $fillable = [
+        'codigo',
+        'nombre',
+        'estado',
+    ];
+}

--- a/database/factories/BodegaFactory.php
+++ b/database/factories/BodegaFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Bodega;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/** @extends Factory<Bodega> */
+class BodegaFactory extends Factory
+{
+    protected $model = Bodega::class;
+
+    public function definition(): array
+    {
+        return [
+            'codigo' => $this->faker->unique()->regexify('BOD-[0-9]{3}'),
+            'nombre' => $this->faker->company(),
+            'estado' => $this->faker->randomElement(['activa','inactiva']),
+        ];
+    }
+}

--- a/database/migrations/2024_01_01_000006_create_bodegas_table.php
+++ b/database/migrations/2024_01_01_000006_create_bodegas_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('bodegas', function (Blueprint $table) {
+            $table->id();
+            $table->string('codigo')->unique();
+            $table->string('nombre');
+            $table->enum('estado', ['activa', 'inactiva'])->default('activa');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('bodegas');
+    }
+};

--- a/database/migrations/2024_01_01_000007_create_inventario_saldos_table.php
+++ b/database/migrations/2024_01_01_000007_create_inventario_saldos_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('inventario_saldos', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('bodega_id')->constrained('bodegas');
+            $table->unsignedBigInteger('producto_id');
+            $table->decimal('cantidad', 15, 4)->default(0);
+            $table->decimal('costo_promedio', 15, 4)->default(0);
+            $table->timestamps();
+            $table->unique(['bodega_id', 'producto_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('inventario_saldos');
+    }
+};

--- a/database/seeders/BodegaSeeder.php
+++ b/database/seeders/BodegaSeeder.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Bodega;
+
+class BodegaSeeder extends Seeder
+{
+    public function run(): void
+    {
+        Bodega::factory()->count(10)->create();
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -14,6 +14,7 @@ class DatabaseSeeder extends Seeder
             LocalesSeeder::class,
             UsersSeeder::class,
             CatalogosBasicosSeeder::class,
+            BodegaSeeder::class,
             // MesasSeeder::class,
             // ProductosDemoSeeder::class,
         ]);

--- a/resources/openapi/bodegas.yaml
+++ b/resources/openapi/bodegas.yaml
@@ -1,0 +1,103 @@
+openapi: 3.0.3
+info:
+  title: Bodegas API
+  version: '1.0'
+paths:
+  /v1/bodegas:
+    get:
+      summary: Listar bodegas
+      parameters:
+        - in: query
+          name: q
+          schema:
+            type: string
+        - in: query
+          name: estado
+          schema:
+            type: string
+            enum: [activa, inactiva]
+        - in: query
+          name: sort
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Lista paginada de bodegas
+    post:
+      summary: Crear bodega
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BodegaInput'
+      responses:
+        '201':
+          description: Bodega creada
+  /v1/bodegas/{id}:
+    get:
+      summary: Obtener bodega
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Bodega
+        '404':
+          description: No encontrada
+    put:
+      summary: Actualizar bodega
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BodegaInput'
+      responses:
+        '200':
+          description: Bodega actualizada
+    delete:
+      summary: Eliminar bodega
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: Eliminada
+components:
+  schemas:
+    Bodega:
+      type: object
+      properties:
+        id:
+          type: integer
+        codigo:
+          type: string
+        nombre:
+          type: string
+        estado:
+          type: string
+          enum: [activa, inactiva]
+    BodegaInput:
+      type: object
+      required: [codigo, nombre, estado]
+      properties:
+        codigo:
+          type: string
+        nombre:
+          type: string
+        estado:
+          type: string
+          enum: [activa, inactiva]

--- a/routes/api.php
+++ b/routes/api.php
@@ -119,10 +119,16 @@ Route::prefix('v1')->middleware('auth.jwt')->group(function () {
 
         Route::get('/proveedores', [ProveedorController::class, 'index'])->middleware('can:proveedores.gestionar');
         Route::post('/proveedores', [ProveedorController::class, 'store'])->middleware('can:proveedores.gestionar');
-        Route::get('/proveedores/{id}', [ProveedorController::class, 'show'])->middleware('can:proveedores.gestionar');
-        Route::put('/proveedores/{id}', [ProveedorController::class, 'update'])->middleware('can:proveedores.gestionar');
-        Route::delete('/proveedores/{id}', [ProveedorController::class, 'destroy'])->middleware('can:proveedores.gestionar');
-    });
+          Route::get('/proveedores/{id}', [ProveedorController::class, 'show'])->middleware('can:proveedores.gestionar');
+          Route::put('/proveedores/{id}', [ProveedorController::class, 'update'])->middleware('can:proveedores.gestionar');
+          Route::delete('/proveedores/{id}', [ProveedorController::class, 'destroy'])->middleware('can:proveedores.gestionar');
 
-    Route::get('/estado-suscripcion', SubscriptionStatusController::class);
-});
+          Route::get('/bodegas', [\App\Http\Controllers\BodegaController::class, 'index']);
+          Route::post('/bodegas', [\App\Http\Controllers\BodegaController::class, 'store']);
+          Route::get('/bodegas/{id}', [\App\Http\Controllers\BodegaController::class, 'show']);
+          Route::put('/bodegas/{id}', [\App\Http\Controllers\BodegaController::class, 'update']);
+          Route::delete('/bodegas/{id}', [\App\Http\Controllers\BodegaController::class, 'destroy']);
+      });
+
+      Route::get('/estado-suscripcion', SubscriptionStatusController::class);
+  });

--- a/tests/Feature/BodegaTest.php
+++ b/tests/Feature/BodegaTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Bodega;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class BodegaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutMiddleware();
+    }
+
+    public function test_can_create_bodega(): void
+    {
+        $response = $this->postJson('/v1/bodegas', [
+            'codigo' => 'BOD-001',
+            'nombre' => 'Matriz',
+            'estado' => 'activa',
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.codigo', 'BOD-001');
+        $this->assertDatabaseHas('bodegas', ['codigo' => 'BOD-001']);
+    }
+
+    public function test_duplicate_codigo_returns_422(): void
+    {
+        Bodega::factory()->create(['codigo' => 'BOD-001']);
+
+        $response = $this->postJson('/v1/bodegas', [
+            'codigo' => 'BOD-001',
+            'nombre' => 'Otra',
+            'estado' => 'activa',
+        ]);
+
+        $response->assertStatus(422);
+    }
+
+    public function test_index_with_filters(): void
+    {
+        Bodega::factory()->create(['codigo' => 'BOD-001', 'nombre' => 'Matriz', 'estado' => 'activa']);
+        Bodega::factory()->create(['codigo' => 'BOD-002', 'nombre' => 'Secundaria', 'estado' => 'inactiva']);
+
+        $response = $this->getJson('/v1/bodegas?q=matriz&estado=activa&sort=-nombre');
+        $response->assertStatus(200)
+            ->assertJsonPath('pagination.total', 1)
+            ->assertJsonPath('data.0.codigo', 'BOD-001');
+    }
+
+    public function test_can_update_bodega(): void
+    {
+        $bodega = Bodega::factory()->create(['codigo' => 'BOD-001', 'nombre' => 'Matriz']);
+
+        $response = $this->putJson("/v1/bodegas/{$bodega->id}", [
+            'codigo' => 'BOD-001',
+            'nombre' => 'Central',
+            'estado' => 'activa',
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.nombre', 'Central');
+    }
+
+    public function test_delete_blocked_when_has_saldo(): void
+    {
+        $bodega = Bodega::factory()->create(['codigo' => 'BOD-001']);
+        DB::table('inventario_saldos')->insert([
+            'bodega_id' => $bodega->id,
+            'producto_id' => 1,
+            'cantidad' => 5,
+            'costo_promedio' => 0,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $response = $this->deleteJson("/v1/bodegas/{$bodega->id}");
+        $response->assertStatus(409);
+    }
+}


### PR DESCRIPTION
## Summary
- add Bodega model, migration, factory and seeder
- implement REST endpoints with validation and resources
- document bodegas API in OpenAPI spec

## Testing
- `phpunit` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689be9b8ee54832fb2dea83c026cd693