### PR TITLE
feat: add accounts payable endpoints

### DIFF
--- a/app/Http/Controllers/CxpController.php
+++ b/app/Http/Controllers/CxpController.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+
+class CxpController extends Controller
+{
+    public function index(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'proveedor_id' => ['nullable', 'uuid'],
+            'estado_saldo' => ['nullable', 'in:pendiente,pagada'],
+            'fecha_desde' => ['nullable', 'date'],
+            'fecha_hasta' => ['nullable', 'date'],
+            'sort' => ['nullable', 'string'],
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => $validator->errors()->toArray(),
+            ], 422);
+        }
+
+        $page = max((int) $request->query('page', 1), 1);
+        $per = (int) $request->query('per_page', 20);
+        $per = $per > 100 ? 100 : $per;
+        $off = ($page - 1) * $per;
+
+        $params = [
+            'proveedor_id' => $request->query('proveedor_id'),
+            'estado_saldo' => $request->query('estado_saldo'),
+            'fini' => $request->query('fecha_desde'),
+            'ffin' => $request->query('fecha_hasta'),
+            'limit' => $per,
+            'offset' => $off,
+        ];
+
+        $sortParam = $request->query('sort');
+        $allowed = ['fecha_emision', 'fecha_vencimiento', 'total', 'saldo_pendiente', 'estado', 'created_at'];
+        $orderParts = [];
+        if ($sortParam) {
+            foreach (explode(',', $sortParam) as $s) {
+                $dir = 'ASC';
+                if (str_starts_with($s, '-')) {
+                    $dir = 'DESC';
+                    $s = substr($s, 1);
+                }
+                if (in_array($s, $allowed, true)) {
+                    $orderParts[] = "cxp.$s $dir";
+                }
+            }
+        }
+        if (!$orderParts) {
+            $orderParts[] = 'cxp.fecha_emision DESC';
+        }
+        $orderBy = implode(', ', $orderParts);
+
+        $sql = "SELECT cxp.* FROM cuentas_por_pagar cxp
+JOIN proveedores p ON p.id = cxp.proveedor_id
+WHERE (:proveedor_id IS NULL OR cxp.proveedor_id = :proveedor_id)
+  AND (:estado_saldo IS NULL OR cxp.estado = :estado_saldo)
+  AND (:fini IS NULL OR cxp.fecha_emision >= :fini)
+  AND (:ffin IS NULL OR cxp.fecha_emision <= :ffin)
+ORDER BY $orderBy
+LIMIT :limit OFFSET :offset";
+        $rows = DB::select($sql, $params);
+
+        $countSql = "SELECT COUNT(1) AS total FROM cuentas_por_pagar cxp
+JOIN proveedores p ON p.id = cxp.proveedor_id
+WHERE (:proveedor_id IS NULL OR cxp.proveedor_id = :proveedor_id)
+  AND (:estado_saldo IS NULL OR cxp.estado = :estado_saldo)
+  AND (:fini IS NULL OR cxp.fecha_emision >= :fini)
+  AND (:ffin IS NULL OR cxp.fecha_emision <= :ffin)";
+        $total = DB::selectOne($countSql, $params)->total ?? 0;
+
+        return [
+            'data' => array_map(fn($r) => (array) $r, $rows),
+            'pagination' => [
+                'page' => $page,
+                'per_page' => $per,
+                'total' => (int) $total,
+            ],
+        ];
+    }
+
+    public function show($id)
+    {
+        $row = DB::selectOne(
+            "SELECT cxp.*, c.numero_factura, c.fecha, p.nombre AS proveedor
+FROM cuentas_por_pagar cxp
+JOIN compras c ON c.id = cxp.compra_id
+JOIN proveedores p ON p.id = cxp.proveedor_id
+WHERE cxp.id = :id
+LIMIT 1",
+            ['id' => $id]
+        );
+        if (!$row) {
+            return response()->json([
+                'error' => 'NotFound',
+                'message' => 'Recurso no encontrado',
+            ], 404);
+        }
+        return ['data' => (array) $row];
+    }
+}

--- a/database/migrations/2024_01_01_000005_create_proveedores_table.php
+++ b/database/migrations/2024_01_01_000005_create_proveedores_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('proveedores', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->unsignedBigInteger('empresa_id');
+            $table->string('identificacion', 20);
+            $table->string('nombre');
+            $table->string('direccion')->nullable();
+            $table->string('telefono', 100)->nullable();
+            $table->string('email')->nullable();
+            $table->timestamps();
+
+            $table->unique(['empresa_id', 'identificacion']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('proveedores');
+    }
+};

--- a/database/migrations/2024_01_01_000008_create_cuentas_por_pagar_table.php
+++ b/database/migrations/2024_01_01_000008_create_cuentas_por_pagar_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('cuentas_por_pagar', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('compra_id');
+            $table->uuid('proveedor_id');
+            $table->date('fecha_emision')->index();
+            $table->date('fecha_vencimiento')->index();
+            $table->decimal('total', 14, 2);
+            $table->decimal('saldo_pendiente', 14, 2);
+            $table->enum('estado', ['pendiente', 'pagada', 'anulada'])->default('pendiente');
+            $table->timestamps();
+
+            $table->foreign('compra_id')->references('id')->on('compras');
+            $table->foreign('proveedor_id')->references('id')->on('proveedores');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('cuentas_por_pagar');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,6 +20,7 @@ use App\Http\Controllers\ProductoController;
 use App\Http\Controllers\RecetaController;
 use App\Http\Controllers\ProductoImportController;
 use App\Http\Controllers\CompraController;
+use App\Http\Controllers\CxpController;
 use App\Http\Controllers\MenuController;
 
 Route::prefix('v1/auth')->group(function () {
@@ -130,6 +131,8 @@ Route::prefix('v1')->middleware('auth.jwt')->group(function () {
         Route::put('/compras/{id}', [CompraController::class, 'update'])->middleware('can:compras.gestionar');
         Route::delete('/compras/{id}', [CompraController::class, 'destroy'])->middleware('can:compras.gestionar');
         Route::post('/compras/{id}/aprobar', [CompraController::class, 'approve'])->middleware('can:compras.gestionar');
+        Route::get('/cxp', [CxpController::class, 'index'])->middleware('can:compras.gestionar');
+        Route::get('/cxp/{id}', [CxpController::class, 'show'])->middleware('can:compras.gestionar');
         Route::get('/bodegas', [\App\Http\Controllers\BodegaController::class, 'index']);
           Route::post('/bodegas', [\App\Http\Controllers\BodegaController::class, 'store']);
           Route::get('/bodegas/{id}', [\App\Http\Controllers\BodegaController::class, 'show']);

--- a/tests/Feature/CxpTest.php
+++ b/tests/Feature/CxpTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class CxpTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutMiddleware();
+    }
+
+    public function test_index_with_filters_and_sort(): void
+    {
+        $prov1 = (string) Str::uuid();
+        $prov2 = (string) Str::uuid();
+        DB::table('proveedores')->insert([
+            ['id' => $prov1, 'empresa_id' => 1, 'identificacion' => '123', 'nombre' => 'Prov Uno', 'created_at' => now(), 'updated_at' => now()],
+            ['id' => $prov2, 'empresa_id' => 1, 'identificacion' => '456', 'nombre' => 'Prov Dos', 'created_at' => now(), 'updated_at' => now()],
+        ]);
+        $comp1 = (string) Str::uuid();
+        $comp2 = (string) Str::uuid();
+        DB::table('compras')->insert([
+            ['id' => $comp1, 'proveedor_id' => $prov1, 'fecha' => '2024-01-10', 'numero_factura' => 'F001', 'subtotal' => 100, 'descuento' => 0, 'impuesto' => 0, 'total' => 100, 'estado' => 'aprobada', 'created_at' => now(), 'updated_at' => now()],
+            ['id' => $comp2, 'proveedor_id' => $prov2, 'fecha' => '2024-01-15', 'numero_factura' => 'F002', 'subtotal' => 200, 'descuento' => 0, 'impuesto' => 0, 'total' => 200, 'estado' => 'aprobada', 'created_at' => now(), 'updated_at' => now()],
+        ]);
+        $cxp1 = (string) Str::uuid();
+        $cxp2 = (string) Str::uuid();
+        DB::table('cuentas_por_pagar')->insert([
+            ['id' => $cxp1, 'compra_id' => $comp1, 'proveedor_id' => $prov1, 'fecha_emision' => '2024-01-10', 'fecha_vencimiento' => '2024-02-10', 'total' => 100, 'saldo_pendiente' => 100, 'estado' => 'pendiente', 'created_at' => now(), 'updated_at' => now()],
+            ['id' => $cxp2, 'compra_id' => $comp2, 'proveedor_id' => $prov2, 'fecha_emision' => '2024-01-15', 'fecha_vencimiento' => '2024-02-15', 'total' => 200, 'saldo_pendiente' => 0, 'estado' => 'pagada', 'created_at' => now(), 'updated_at' => now()],
+        ]);
+
+        $res = $this->getJson('/v1/cxp?sort=-fecha_emision');
+        $res->assertStatus(200)
+            ->assertJsonPath('pagination.total', 2)
+            ->assertJsonPath('data.0.id', $cxp2);
+
+        $res = $this->getJson("/v1/cxp?proveedor_id=$prov1&estado_saldo=pendiente&fecha_desde=2024-01-01&fecha_hasta=2024-01-31");
+        $res->assertStatus(200)
+            ->assertJsonPath('pagination.total', 1)
+            ->assertJsonPath('data.0.id', $cxp1);
+    }
+
+    public function test_show_returns_detail(): void
+    {
+        $prov = (string) Str::uuid();
+        DB::table('proveedores')->insert([
+            'id' => $prov,
+            'empresa_id' => 1,
+            'identificacion' => '789',
+            'nombre' => 'Proveedor X',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+        $comp = (string) Str::uuid();
+        DB::table('compras')->insert([
+            'id' => $comp,
+            'proveedor_id' => $prov,
+            'fecha' => '2024-01-20',
+            'numero_factura' => 'F010',
+            'subtotal' => 50,
+            'descuento' => 0,
+            'impuesto' => 0,
+            'total' => 50,
+            'estado' => 'aprobada',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+        $cxp = (string) Str::uuid();
+        DB::table('cuentas_por_pagar')->insert([
+            'id' => $cxp,
+            'compra_id' => $comp,
+            'proveedor_id' => $prov,
+            'fecha_emision' => '2024-01-20',
+            'fecha_vencimiento' => '2024-02-20',
+            'total' => 50,
+            'saldo_pendiente' => 50,
+            'estado' => 'pendiente',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $res = $this->getJson("/v1/cxp/$cxp");
+        $res->assertStatus(200)
+            ->assertJsonPath('data.id', $cxp)
+            ->assertJsonPath('data.numero_factura', 'F010')
+            ->assertJsonPath('data.proveedor', 'Proveedor X');
+    }
+}


### PR DESCRIPTION
## Summary
- add controller and routes for listing and viewing cuentas por pagar with filters and multi-sort
- create migrations for proveedores and cuentas_por_pagar tables
- cover accounts payable endpoints with feature tests

## Testing
- `composer test` *(fails: vendor autoload missing)*
- `composer install --no-interaction` *(fails: GitHub 403 while downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_689bef03c100832f81378f63cda02b8c