### PR TITLE
feat: add provider payment endpoint

### DIFF
--- a/app/Http/Controllers/PagoProveedorController.php
+++ b/app/Http/Controllers/PagoProveedorController.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Str;
+
+class PagoProveedorController extends Controller
+{
+    public function store(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'cxp_id' => ['required', 'uuid'],
+            'fecha_pago' => ['required', 'date'],
+            'monto' => ['required', 'numeric', 'min:0.01'],
+            'forma_pago' => ['required', 'string', 'max:50'],
+            'referencia' => ['nullable', 'string', 'max:100'],
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => $validator->errors()->toArray(),
+            ], 422);
+        }
+
+        $data = $validator->validated();
+
+        DB::beginTransaction();
+        try {
+            $cxp = DB::selectOne(
+                'SELECT id, saldo_pendiente, estado FROM cuentas_por_pagar WHERE id = :id FOR UPDATE',
+                ['id' => $data['cxp_id']]
+            );
+            if (!$cxp) {
+                DB::rollBack();
+                return response()->json([
+                    'error' => 'NotFound',
+                    'message' => 'Recurso no encontrado',
+                ], 404);
+            }
+            if ($cxp->estado !== 'pendiente') {
+                DB::rollBack();
+                return response()->json([
+                    'error' => 'Conflict',
+                    'message' => 'La cuenta no está pendiente',
+                ], 409);
+            }
+            if ($data['monto'] > $cxp->saldo_pendiente) {
+                DB::rollBack();
+                return response()->json([
+                    'error' => 'Conflict',
+                    'message' => 'El monto excede el saldo pendiente',
+                ], 409);
+            }
+
+            $id = (string) Str::uuid();
+            DB::insert(
+                'INSERT INTO pagos_proveedor(id, cxp_id, fecha_pago, monto, forma_pago, referencia, created_at, updated_at)
+                VALUES (:id, :cxp_id, :fecha_pago, :monto, :forma_pago, :referencia, NOW(), NOW())',
+                [
+                    'id' => $id,
+                    'cxp_id' => $data['cxp_id'],
+                    'fecha_pago' => $data['fecha_pago'],
+                    'monto' => $data['monto'],
+                    'forma_pago' => $data['forma_pago'],
+                    'referencia' => $data['referencia'],
+                ]
+            );
+
+            DB::update(
+                "UPDATE cuentas_por_pagar
+SET saldo_pendiente = saldo_pendiente - :monto,
+    estado = CASE WHEN saldo_pendiente - :monto <= 0 THEN 'pagada' ELSE 'pendiente' END,
+    updated_at = NOW()
+WHERE id = :cxp_id",
+                [
+                    'monto' => $data['monto'],
+                    'cxp_id' => $data['cxp_id'],
+                ]
+            );
+
+            $row = DB::selectOne('SELECT * FROM pagos_proveedor WHERE id = :id', ['id' => $id]);
+            DB::commit();
+            return response()->json(['data' => (array) $row], 201);
+        } catch (\Throwable $e) {
+            DB::rollBack();
+            throw $e;
+        }
+    }
+}

--- a/database/migrations/2024_01_01_000009_create_pagos_proveedor_table.php
+++ b/database/migrations/2024_01_01_000009_create_pagos_proveedor_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('pagos_proveedor', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('cxp_id');
+            $table->date('fecha_pago');
+            $table->decimal('monto', 14, 2);
+            $table->string('forma_pago', 50);
+            $table->string('referencia', 100)->nullable();
+            $table->uuid('usuario_id')->nullable();
+            $table->timestamps();
+
+            $table->foreign('cxp_id')->references('id')->on('cuentas_por_pagar');
+            $table->foreign('usuario_id')->references('id')->on('users');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('pagos_proveedor');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,6 +21,7 @@ use App\Http\Controllers\RecetaController;
 use App\Http\Controllers\ProductoImportController;
 use App\Http\Controllers\CompraController;
 use App\Http\Controllers\CxpController;
+use App\Http\Controllers\PagoProveedorController;
 use App\Http\Controllers\MenuController;
 
 Route::prefix('v1/auth')->group(function () {
@@ -133,6 +134,7 @@ Route::prefix('v1')->middleware('auth.jwt')->group(function () {
         Route::post('/compras/{id}/aprobar', [CompraController::class, 'approve'])->middleware('can:compras.gestionar');
         Route::get('/cxp', [CxpController::class, 'index'])->middleware('can:compras.gestionar');
         Route::get('/cxp/{id}', [CxpController::class, 'show'])->middleware('can:compras.gestionar');
+        Route::post('/pagos-proveedor', [PagoProveedorController::class, 'store'])->middleware('can:compras.gestionar');
         Route::get('/bodegas', [\App\Http\Controllers\BodegaController::class, 'index']);
           Route::post('/bodegas', [\App\Http\Controllers\BodegaController::class, 'store']);
           Route::get('/bodegas/{id}', [\App\Http\Controllers\BodegaController::class, 'show']);

--- a/tests/Feature/PagoProveedorTest.php
+++ b/tests/Feature/PagoProveedorTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class PagoProveedorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutMiddleware();
+    }
+
+    public function test_store_creates_payment_and_updates_cxp(): void
+    {
+        $prov = (string) Str::uuid();
+        DB::table('proveedores')->insert([
+            'id' => $prov,
+            'empresa_id' => 1,
+            'identificacion' => '123',
+            'nombre' => 'Prov',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+        $compra = (string) Str::uuid();
+        DB::table('compras')->insert([
+            'id' => $compra,
+            'proveedor_id' => $prov,
+            'fecha' => '2024-01-01',
+            'numero_factura' => 'F1',
+            'subtotal' => 100,
+            'descuento' => 0,
+            'impuesto' => 0,
+            'total' => 100,
+            'estado' => 'aprobada',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+        $cxp = (string) Str::uuid();
+        DB::table('cuentas_por_pagar')->insert([
+            'id' => $cxp,
+            'compra_id' => $compra,
+            'proveedor_id' => $prov,
+            'fecha_emision' => '2024-01-01',
+            'fecha_vencimiento' => '2024-02-01',
+            'total' => 100,
+            'saldo_pendiente' => 100,
+            'estado' => 'pendiente',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $res = $this->postJson('/v1/pagos-proveedor', [
+            'cxp_id' => $cxp,
+            'fecha_pago' => '2024-01-10',
+            'monto' => 60,
+            'forma_pago' => 'efectivo',
+            'referencia' => 'ref123',
+        ]);
+        $res->assertStatus(201)
+            ->assertJsonPath('data.cxp_id', $cxp);
+
+        $saldo = DB::table('cuentas_por_pagar')->where('id', $cxp)->value('saldo_pendiente');
+        $estado = DB::table('cuentas_por_pagar')->where('id', $cxp)->value('estado');
+        $this->assertEquals(40.0, (float) $saldo);
+        $this->assertEquals('pendiente', $estado);
+    }
+
+    public function test_store_fails_when_monto_exceeds_saldo(): void
+    {
+        $prov = (string) Str::uuid();
+        DB::table('proveedores')->insert([
+            'id' => $prov,
+            'empresa_id' => 1,
+            'identificacion' => '456',
+            'nombre' => 'Prov2',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+        $compra = (string) Str::uuid();
+        DB::table('compras')->insert([
+            'id' => $compra,
+            'proveedor_id' => $prov,
+            'fecha' => '2024-01-05',
+            'numero_factura' => 'F2',
+            'subtotal' => 80,
+            'descuento' => 0,
+            'impuesto' => 0,
+            'total' => 80,
+            'estado' => 'aprobada',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+        $cxp = (string) Str::uuid();
+        DB::table('cuentas_por_pagar')->insert([
+            'id' => $cxp,
+            'compra_id' => $compra,
+            'proveedor_id' => $prov,
+            'fecha_emision' => '2024-01-05',
+            'fecha_vencimiento' => '2024-02-05',
+            'total' => 80,
+            'saldo_pendiente' => 80,
+            'estado' => 'pendiente',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $res = $this->postJson('/v1/pagos-proveedor', [
+            'cxp_id' => $cxp,
+            'fecha_pago' => '2024-01-15',
+            'monto' => 100,
+            'forma_pago' => 'transferencia',
+        ]);
+        $res->assertStatus(409);
+    }
+}


### PR DESCRIPTION
## Summary
- add `/v1/pagos-proveedor` route to register supplier payments
- store payments and update accounts payable balance in a single transaction
- create migration and feature tests for provider payment flow

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_689bf09aa530832f82e6370d09550b29