### PR TITLE
Implement basic pedidos API with idempotency middleware

### DIFF
--- a/app/Http/Controllers/PedidoController.php
+++ b/app/Http/Controllers/PedidoController.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StorePedidoRequest;
+use App\Http\Requests\UpdatePedidoRequest;
+use App\Http\Resources\PedidoResource;
+use App\Models\Pedido;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class PedidoController extends Controller
+{
+    /**
+     * @OA\Get(path="/v1/pedidos", summary="Listar pedidos", @OA\Response(response=200, description="OK"))
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $pedidos = Pedido::query()->paginate();
+        return response()->json([
+            'data' => PedidoResource::collection($pedidos),
+            'meta' => ['current_page' => $pedidos->currentPage(), 'total' => $pedidos->total()],
+            'links' => ['self' => $request->fullUrl()],
+        ]);
+    }
+
+    /**
+     * @OA\Post(
+     *   path="/v1/pedidos",
+     *   summary="Crear pedido",
+     *   @OA\RequestBody(required=true, @OA\JsonContent(required={"origen"},
+     *       @OA\Property(property="origen", type="string", example="salon")
+     *   )),
+     *   @OA\Response(response=201, description="Pedido creado")
+     * )
+     */
+    public function store(StorePedidoRequest $request): JsonResponse
+    {
+        $pedido = DB::transaction(fn() => Pedido::create($request->validated()));
+        return response()->json(['data' => new PedidoResource($pedido)], 201);
+    }
+
+    /**
+     * @OA\Get(path="/v1/pedidos/{id}", summary="Mostrar pedido", @OA\Parameter(name="id", in="path", required=true, schema=@OA\Schema(type="string")), @OA\Response(response=200, description="OK"))
+     */
+    public function show(Pedido $pedido): JsonResponse
+    {
+        return response()->json(['data' => new PedidoResource($pedido)]);
+    }
+
+    /**
+     * @OA\Put(path="/v1/pedidos/{id}", summary="Actualizar pedido", @OA\Parameter(name="id", in="path", required=true, schema=@OA\Schema(type="string")), @OA\Response(response=200, description="OK"))
+     */
+    public function update(UpdatePedidoRequest $request, Pedido $pedido): JsonResponse
+    {
+        $pedido->update($request->validated());
+        return response()->json(['data' => new PedidoResource($pedido)]);
+    }
+
+    /**
+     * @OA\Delete(path="/v1/pedidos/{id}", summary="Eliminar pedido", @OA\Parameter(name="id", in="path", required=true, schema=@OA\Schema(type="string")), @OA\Response(response=200, description="OK"))
+     */
+    public function destroy(Pedido $pedido): JsonResponse
+    {
+        $pedido->delete();
+        return response()->json(['data' => true]);
+    }
+}

--- a/app/Http/Middleware/IdempotencyMiddleware.php
+++ b/app/Http/Middleware/IdempotencyMiddleware.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Symfony\Component\HttpFoundation\Response;
+
+class IdempotencyMiddleware
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $key = $request->header('Idempotency-Key');
+        if (!$key) {
+            return $next($request);
+        }
+
+        $hash = sha1($request->getContent());
+        $entry = DB::table('idempotencies')->where('key', $key)->first();
+        if ($entry) {
+            abort(409, 'Duplicate request');
+        }
+
+        $response = $next($request);
+
+        DB::table('idempotencies')->insert([
+            'id' => (string)\Illuminate\Support\Str::uuid(),
+            'key' => $key,
+            'endpoint' => $request->path(),
+            'body_hash' => $hash,
+            'response_hash' => sha1($response->getContent()),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $response;
+    }
+}

--- a/app/Http/Requests/StorePedidoRequest.php
+++ b/app/Http/Requests/StorePedidoRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StorePedidoRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'mesa_id' => ['nullable','uuid'],
+            'cliente_nombre' => ['nullable','string','max:120'],
+            'origen' => ['required','in:salon,para_llevar,delivery'],
+            'notas' => ['nullable','string','max:255'],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdatePedidoRequest.php
+++ b/app/Http/Requests/UpdatePedidoRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdatePedidoRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'mesa_id' => ['nullable','uuid'],
+            'cliente_nombre' => ['nullable','string','max:120'],
+            'origen' => ['required','in:salon,para_llevar,delivery'],
+            'notas' => ['nullable','string','max:255'],
+        ];
+    }
+}

--- a/app/Http/Resources/PedidoResource.php
+++ b/app/Http/Resources/PedidoResource.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class PedidoResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'mesa_id' => $this->mesa_id,
+            'cliente_nombre' => $this->cliente_nombre,
+            'estado' => $this->estado,
+            'origen' => $this->origen,
+            'notas' => $this->notas,
+            'subtotal' => $this->subtotal,
+            'descuento' => $this->descuento,
+            'impuesto' => $this->impuesto,
+            'total' => $this->total,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/app/Models/Pedido.php
+++ b/app/Models/Pedido.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Pedido extends Model
+{
+    use HasUuids, SoftDeletes;
+
+    protected $fillable = [
+        'mesa_id',
+        'cliente_nombre',
+        'estado',
+        'origen',
+        'notas',
+        'subtotal',
+        'descuento',
+        'impuesto',
+        'total',
+        'created_by',
+    ];
+
+    public function items(): HasMany
+    {
+        return $this->hasMany(PedidoItem::class);
+    }
+}

--- a/app/Models/PedidoItem.php
+++ b/app/Models/PedidoItem.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PedidoItem extends Model
+{
+    use HasUuids, SoftDeletes;
+
+    protected $fillable = [
+        'pedido_id',
+        'producto_id',
+        'nombre',
+        'cantidad',
+        'precio_unit',
+        'impuesto_porcentaje',
+        'notas',
+        'estado',
+        'estacion',
+        'orden_sec',
+    ];
+
+    public function pedido(): BelongsTo
+    {
+        return $this->belongsTo(Pedido::class);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -16,6 +16,7 @@ return Application::configure(basePath: dirname(__DIR__))
             'auth.jwt' => \App\Http\Middleware\JwtMiddleware::class,
             'check.subscription' => \App\Http\Middleware\CheckSubscription::class,
             'can.any' => \App\Http\Middleware\CanAny::class,
+            'idempotency' => \App\Http\Middleware\IdempotencyMiddleware::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {

--- a/database/migrations/2024_08_13_000001_create_pedidos_table.php
+++ b/database/migrations/2024_08_13_000001_create_pedidos_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('pedidos', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('mesa_id')->nullable();
+            $table->string('cliente_nombre',120)->nullable();
+            $table->enum('estado', ['abierto','enviado','preparando','listo','servido','cerrado','anulado'])->default('abierto')->index();
+            $table->enum('origen', ['salon','para_llevar','delivery'])->default('salon');
+            $table->string('notas',255)->nullable();
+            $table->decimal('subtotal',14,2)->default(0);
+            $table->decimal('descuento',14,2)->default(0);
+            $table->decimal('impuesto',14,2)->default(0);
+            $table->decimal('total',14,2)->default(0);
+            $table->uuid('created_by')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('pedidos');
+    }
+};

--- a/database/migrations/2024_08_13_000002_create_pedido_items_table.php
+++ b/database/migrations/2024_08_13_000002_create_pedido_items_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('pedido_items', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('pedido_id')->constrained('pedidos');
+            $table->uuid('producto_id');
+            $table->string('nombre',150);
+            $table->decimal('cantidad',12,4);
+            $table->decimal('precio_unit',12,2);
+            $table->decimal('impuesto_porcentaje',5,2)->default(0);
+            $table->string('notas',255)->nullable();
+            $table->enum('estado', ['pendiente','en_cola','en_proceso','listo','servido','anulado'])->default('pendiente')->index();
+            $table->enum('estacion', ['cocina','bar','postres','otros'])->index();
+            $table->unsignedBigInteger('orden_sec');
+            $table->timestamps();
+            $table->softDeletes();
+            $table->index(['pedido_id','estado','estacion','orden_sec']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('pedido_items');
+    }
+};

--- a/database/migrations/2024_08_13_000003_create_idempotencies_table.php
+++ b/database/migrations/2024_08_13_000003_create_idempotencies_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('idempotencies', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('key')->unique();
+            $table->string('endpoint');
+            $table->string('body_hash');
+            $table->string('response_hash')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('idempotencies');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -22,6 +22,7 @@ use App\Http\Controllers\ProductoImportController;
 use App\Http\Controllers\CompraController;
 use App\Http\Controllers\CxpController;
 use App\Http\Controllers\MenuController;
+use App\Http\Controllers\PedidoController;
 
 Route::prefix('v1/auth')->group(function () {
     Route::post('/login', [AuthController::class, 'login']);
@@ -33,6 +34,10 @@ Route::prefix('v1/auth')->group(function () {
 });
 
 Route::get('/v1/menu', [MenuController::class, 'index']);
+
+Route::prefix('v1')->middleware('idempotency')->group(function () {
+    Route::apiResource('pedidos', PedidoController::class);
+});
 
 Route::prefix('v1')->middleware('auth.jwt')->group(function () {
     Route::middleware('check.subscription')->group(function () {

--- a/tests/Feature/PedidoTest.php
+++ b/tests/Feature/PedidoTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Pedido;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PedidoTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_create_pedido(): void
+    {
+        $response = $this->postJson('/api/v1/pedidos', [
+            'origen' => 'salon'
+        ]);
+
+        $response->assertCreated();
+        $this->assertDatabaseCount('pedidos', 1);
+    }
+
+    public function test_create_pedido_validation_error(): void
+    {
+        $response = $this->postJson('/api/v1/pedidos', []);
+        $response->assertStatus(422);
+    }
+}


### PR DESCRIPTION
## Summary
- add Pedido model, migrations and API resource
- implement simple pedidos API with optional Idempotency-Key middleware
- include basic feature tests and OpenAPI annotations

## Testing
- `php artisan test` *(fails: Class `Illuminate\Foundation\Application` not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bf0e2654c832f99c498061246a11e