### PR TITLE
feat: add mesas resource

### DIFF
--- a/app/Http/Controllers/MesaController.php
+++ b/app/Http/Controllers/MesaController.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreMesaRequest;
+use App\Http\Requests\UpdateMesaRequest;
+use App\Http\Resources\MesaCollection;
+use App\Http\Resources\MesaResource;
+use App\Models\Mesa;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class MesaController extends Controller
+{
+    public function index(Request $request)
+    {
+        $query = Mesa::query();
+
+        if ($estado = $request->query('estado')) {
+            $query->where('estado', $estado);
+        }
+
+        if ($ubicacion = $request->query('ubicacion')) {
+            $query->where('ubicacion', $ubicacion);
+        }
+
+        if ($capMin = $request->query('capacidad_min')) {
+            $query->where('capacidad', '>=', (int) $capMin);
+        }
+
+        if ($capMax = $request->query('capacidad_max')) {
+            $query->where('capacidad', '<=', (int) $capMax);
+        }
+
+        if ($q = $request->query('q')) {
+            $query->where(function ($q2) use ($q) {
+                $q2->where('codigo', 'like', "%$q%")
+                    ->orWhere('nombre', 'like', "%$q%");
+            });
+        }
+
+        if ($sort = $request->query('sort')) {
+            foreach (explode(',', $sort) as $part) {
+                $direction = 'asc';
+                $column = $part;
+                if (str_starts_with($part, '-')) {
+                    $direction = 'desc';
+                    $column = substr($part, 1);
+                }
+                if (in_array($column, ['codigo', 'nombre', 'capacidad', 'estado', 'ubicacion'])) {
+                    $query->orderBy($column, $direction);
+                }
+            }
+        }
+
+        $perPage = min($request->query('per_page', 20), 100);
+        $mesas = $query->paginate($perPage);
+
+        return new MesaCollection($mesas);
+    }
+
+    public function store(StoreMesaRequest $request)
+    {
+        $mesa = Mesa::create($request->validated());
+        return (new MesaResource($mesa))->response()->setStatusCode(201);
+    }
+
+    public function show($id)
+    {
+        $mesa = Mesa::find($id);
+        if (!$mesa) {
+            return response()->json([
+                'error' => 'NotFound',
+                'message' => 'Recurso no encontrado',
+            ], 404);
+        }
+        return new MesaResource($mesa);
+    }
+
+    public function update(UpdateMesaRequest $request, $id)
+    {
+        $mesa = Mesa::find($id);
+        if (!$mesa) {
+            return response()->json([
+                'error' => 'NotFound',
+                'message' => 'Recurso no encontrado',
+            ], 404);
+        }
+        $mesa->update($request->validated());
+        return new MesaResource($mesa);
+    }
+
+    public function destroy($id)
+    {
+        $mesa = Mesa::find($id);
+        if (!$mesa) {
+            return response()->json([
+                'error' => 'NotFound',
+                'message' => 'Recurso no encontrado',
+            ], 404);
+        }
+
+        $futuras = DB::table('reservas')
+            ->where('mesa_id', $id)
+            ->whereIn('estado', ['pendiente', 'confirmada'])
+            ->where('inicio', '>=', now())
+            ->count();
+
+        if ($futuras > 0) {
+            return response()->json([
+                'error' => 'Unprocessable',
+                'message' => 'La mesa tiene reservas futuras',
+            ], 422);
+        }
+
+        $mesa->delete();
+        return response()->json(null, 204);
+    }
+}

--- a/app/Http/Requests/StoreMesaRequest.php
+++ b/app/Http/Requests/StoreMesaRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreMesaRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'codigo' => ['required', 'string', 'max:20', 'unique:mesas,codigo'],
+            'nombre' => ['nullable', 'string', 'max:100'],
+            'capacidad' => ['required', 'integer', 'min:1'],
+            'ubicacion' => ['required', 'in:salon,terraza,barra,privado'],
+            'estado' => ['required', 'in:activa,inactiva'],
+            'notas' => ['nullable', 'string', 'max:255'],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateMesaRequest.php
+++ b/app/Http/Requests/UpdateMesaRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateMesaRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        $id = $this->route('id');
+        return [
+            'codigo' => ['required', 'string', 'max:20', Rule::unique('mesas', 'codigo')->ignore($id)],
+            'nombre' => ['nullable', 'string', 'max:100'],
+            'capacidad' => ['required', 'integer', 'min:1'],
+            'ubicacion' => ['required', 'in:salon,terraza,barra,privado'],
+            'estado' => ['required', 'in:activa,inactiva'],
+            'notas' => ['nullable', 'string', 'max:255'],
+        ];
+    }
+}

--- a/app/Http/Resources/MesaCollection.php
+++ b/app/Http/Resources/MesaCollection.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class MesaCollection extends ResourceCollection
+{
+    public function toArray($request): array
+    {
+        return [
+            'data' => MesaResource::collection($this->collection),
+            'pagination' => [
+                'current_page' => $this->currentPage(),
+                'per_page' => $this->perPage(),
+                'total' => $this->total(),
+            ],
+        ];
+    }
+}

--- a/app/Http/Resources/MesaResource.php
+++ b/app/Http/Resources/MesaResource.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin \App\Models\Mesa */
+class MesaResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'codigo' => $this->codigo,
+            'nombre' => $this->nombre,
+            'capacidad' => $this->capacidad,
+            'ubicacion' => $this->ubicacion,
+            'estado' => $this->estado,
+            'notas' => $this->notas,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/app/Models/Mesa.php
+++ b/app/Models/Mesa.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Mesa extends Model
+{
+    use HasFactory, HasUuids, SoftDeletes;
+
+    protected $fillable = [
+        'codigo',
+        'nombre',
+        'capacidad',
+        'ubicacion',
+        'estado',
+        'notas',
+    ];
+}

--- a/database/migrations/2024_08_13_000004_create_mesas_table.php
+++ b/database/migrations/2024_08_13_000004_create_mesas_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('mesas', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('codigo', 20)->unique();
+            $table->string('nombre', 100)->nullable();
+            $table->unsignedInteger('capacidad');
+            $table->enum('ubicacion', ['salon','terraza','barra','privado'])->default('salon')->index();
+            $table->enum('estado', ['activa','inactiva'])->default('activa')->index();
+            $table->string('notas', 255)->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('mesas');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -145,6 +145,11 @@ Route::prefix('v1')->middleware('auth.jwt')->group(function () {
           Route::get('/bodegas/{id}', [\App\Http\Controllers\BodegaController::class, 'show']);
           Route::put('/bodegas/{id}', [\App\Http\Controllers\BodegaController::class, 'update']);
           Route::delete('/bodegas/{id}', [\App\Http\Controllers\BodegaController::class, 'destroy']);
+        Route::get('/mesas', [\App\Http\Controllers\MesaController::class, 'index']);
+          Route::post('/mesas', [\App\Http\Controllers\MesaController::class, 'store']);
+          Route::get('/mesas/{id}', [\App\Http\Controllers\MesaController::class, 'show']);
+          Route::put('/mesas/{id}', [\App\Http\Controllers\MesaController::class, 'update']);
+          Route::delete('/mesas/{id}', [\App\Http\Controllers\MesaController::class, 'destroy']);
     });
 
     Route::get('/estado-suscripcion', SubscriptionStatusController::class);


### PR DESCRIPTION
## Summary
- add Mesas API resource with filtering, sorting and soft delete
- validate unique codigo and positive capacity
- prevent deleting mesas with future reservations

## Testing
- `composer test` *(fails: Script @php artisan config:clear --ansi handling the test event returned with error code 255)*
- `composer install --no-interaction --prefer-dist` *(fails: CONNECT tunnel failed, response 403 while downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689bf24b65c0832fba02c7501bdbc482