### PR TITLE
feat: add table reservation availability service

### DIFF
--- a/app/Http/Controllers/ReservaController.php
+++ b/app/Http/Controllers/ReservaController.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreReservaRequest;
+use App\Http\Requests\UpdateReservaRequest;
+use App\Http\Resources\ReservaResource;
+use App\Models\Reserva;
+use App\Services\MesaAvailabilityService;
+use Illuminate\Http\JsonResponse;
+
+class ReservaController extends Controller
+{
+    public function store(StoreReservaRequest $request, MesaAvailabilityService $service): JsonResponse
+    {
+        $data = $request->validated();
+
+        if (!$service->isAvailable($data['mesa_id'], $data['inicio'], $data['fin'])) {
+            return response()->json([
+                'errors' => [
+                    'mesa_id' => ['La mesa no está disponible en el rango de tiempo indicado.'],
+                ],
+            ], 422);
+        }
+
+        $reserva = Reserva::create($data);
+
+        return response()->json(['data' => new ReservaResource($reserva)], 201);
+    }
+
+    public function update(UpdateReservaRequest $request, Reserva $reserva, MesaAvailabilityService $service): JsonResponse
+    {
+        $data = $request->validated();
+
+        if (!$service->isAvailable($data['mesa_id'], $data['inicio'], $data['fin'], $reserva->id)) {
+            return response()->json([
+                'errors' => [
+                    'mesa_id' => ['La mesa no está disponible en el rango de tiempo indicado.'],
+                ],
+            ], 422);
+        }
+
+        $reserva->update($data);
+
+        return response()->json(['data' => new ReservaResource($reserva)]);
+    }
+
+    public function confirm(Reserva $reserva, MesaAvailabilityService $service): JsonResponse
+    {
+        if (!$service->isAvailable($reserva->mesa_id, $reserva->inicio, $reserva->fin, $reserva->id)) {
+            return response()->json([
+                'errors' => [
+                    'mesa_id' => ['La mesa no está disponible en el rango de tiempo indicado.'],
+                ],
+            ], 422);
+        }
+
+        $reserva->estado = 'confirmada';
+        $reserva->save();
+
+        return response()->json(['data' => new ReservaResource($reserva)]);
+    }
+}

--- a/app/Http/Requests/StoreReservaRequest.php
+++ b/app/Http/Requests/StoreReservaRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreReservaRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'mesa_id' => ['required', 'uuid'],
+            'inicio' => ['required', 'date'],
+            'fin' => ['required', 'date', 'after:inicio'],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateReservaRequest.php
+++ b/app/Http/Requests/UpdateReservaRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateReservaRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'mesa_id' => ['required', 'uuid'],
+            'inicio' => ['required', 'date'],
+            'fin' => ['required', 'date', 'after:inicio'],
+        ];
+    }
+}

--- a/app/Http/Resources/ReservaResource.php
+++ b/app/Http/Resources/ReservaResource.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ReservaResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'mesa_id' => $this->mesa_id,
+            'inicio' => $this->inicio,
+            'fin' => $this->fin,
+            'estado' => $this->estado,
+        ];
+    }
+}

--- a/app/Models/Reserva.php
+++ b/app/Models/Reserva.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Reserva extends Model
+{
+    use HasUuids, SoftDeletes;
+
+    protected $fillable = [
+        'mesa_id',
+        'inicio',
+        'fin',
+        'estado',
+    ];
+}

--- a/app/Services/MesaAvailabilityService.php
+++ b/app/Services/MesaAvailabilityService.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\DB;
+
+class MesaAvailabilityService
+{
+    public function findConflict(string $mesaId, string $inicio, string $fin, ?string $excludeId = null): ?object
+    {
+        $query = DB::table('reservas as r')
+            ->select('r.id', 'r.inicio', 'r.fin', 'r.estado')
+            ->where('r.mesa_id', $mesaId)
+            ->whereIn('r.estado', ['pendiente', 'confirmada'])
+            ->where(function ($q) use ($inicio, $fin) {
+                $q->where('r.inicio', '<', $fin)
+                    ->where('r.fin', '>', $inicio);
+            })
+            ->orderBy('r.inicio', 'asc');
+
+        if ($excludeId) {
+            $query->where('r.id', '!=', $excludeId);
+        }
+
+        return $query->first();
+    }
+
+    public function isAvailable(string $mesaId, string $inicio, string $fin, ?string $excludeId = null): bool
+    {
+        return $this->findConflict($mesaId, $inicio, $fin, $excludeId) === null;
+    }
+}

--- a/database/migrations/2024_08_13_000004_create_reservas_table.php
+++ b/database/migrations/2024_08_13_000004_create_reservas_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('reservas', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('mesa_id');
+            $table->timestamp('inicio');
+            $table->timestamp('fin');
+            $table->enum('estado', ['pendiente', 'confirmada', 'cancelada'])->default('pendiente')->index();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('reservas');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -24,6 +24,7 @@ use App\Http\Controllers\CxpController;
 use App\Http\Controllers\PagoProveedorController;
 use App\Http\Controllers\MenuController;
 use App\Http\Controllers\PedidoController;
+use App\Http\Controllers\ReservaController;
 
 Route::prefix('v1/auth')->group(function () {
     Route::post('/login', [AuthController::class, 'login']);
@@ -38,6 +39,8 @@ Route::get('/v1/menu', [MenuController::class, 'index']);
 
 Route::prefix('v1')->middleware('idempotency')->group(function () {
     Route::apiResource('pedidos', PedidoController::class);
+    Route::apiResource('reservas', ReservaController::class)->only(['store', 'update']);
+    Route::post('/reservas/{reserva}/confirmar', [ReservaController::class, 'confirm']);
 });
 
 Route::prefix('v1')->middleware('auth.jwt')->group(function () {

--- a/tests/Feature/ReservaTest.php
+++ b/tests/Feature/ReservaTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Reserva;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class ReservaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_create_reserva_success(): void
+    {
+        $mesaId = (string) Str::uuid();
+
+        $response = $this->postJson('/api/v1/reservas', [
+            'mesa_id' => $mesaId,
+            'inicio' => '2024-01-01 10:00:00',
+            'fin' => '2024-01-01 11:00:00',
+        ]);
+
+        $response->assertCreated();
+        $this->assertDatabaseCount('reservas', 1);
+    }
+
+    public function test_create_reserva_conflict(): void
+    {
+        $mesaId = (string) Str::uuid();
+
+        $this->postJson('/api/v1/reservas', [
+            'mesa_id' => $mesaId,
+            'inicio' => '2024-01-01 10:00:00',
+            'fin' => '2024-01-01 11:00:00',
+        ]);
+
+        $response = $this->postJson('/api/v1/reservas', [
+            'mesa_id' => $mesaId,
+            'inicio' => '2024-01-01 10:30:00',
+            'fin' => '2024-01-01 11:30:00',
+        ]);
+
+        $response->assertStatus(422);
+        $this->assertDatabaseCount('reservas', 1);
+    }
+
+    public function test_confirm_reserva_success(): void
+    {
+        $reserva = Reserva::create([
+            'mesa_id' => (string) Str::uuid(),
+            'inicio' => '2024-01-01 10:00:00',
+            'fin' => '2024-01-01 11:00:00',
+        ]);
+
+        $response = $this->postJson("/api/v1/reservas/{$reserva->id}/confirmar");
+
+        $response->assertOk();
+        $this->assertDatabaseHas('reservas', ['id' => $reserva->id, 'estado' => 'confirmada']);
+    }
+
+    public function test_confirm_reserva_conflict(): void
+    {
+        $mesaId = (string) Str::uuid();
+
+        Reserva::create([
+            'mesa_id' => $mesaId,
+            'inicio' => '2024-01-01 10:00:00',
+            'fin' => '2024-01-01 11:00:00',
+            'estado' => 'confirmada',
+        ]);
+
+        $reservaPendiente = Reserva::create([
+            'mesa_id' => $mesaId,
+            'inicio' => '2024-01-01 10:30:00',
+            'fin' => '2024-01-01 11:30:00',
+        ]);
+
+        $response = $this->postJson("/api/v1/reservas/{$reservaPendiente->id}/confirmar");
+
+        $response->assertStatus(422);
+        $this->assertDatabaseHas('reservas', ['id' => $reservaPendiente->id, 'estado' => 'pendiente']);
+    }
+}


### PR DESCRIPTION
## Summary
- add MesaAvailabilityService to check table reservation conflicts
- implement ReservaController with store, update and confirm endpoints
- create migrations, model, requests, resource and feature tests for reservations

## Testing
- `composer test` *(fails: require vendor autoload; composer install requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_689bf26ae610832f8067026bf8682c96