### PR TITLE
feat: add reservation status transition endpoints

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -43,6 +43,9 @@ Route::prefix('v1')->middleware('idempotency')->group(function () {
 
 Route::prefix('v1')->group(function () {
     Route::apiResource('reservas', ReservaController::class);
+    Route::post('reservas/{id}/confirmar', [ReservaController::class, 'confirm']);
+    Route::post('reservas/{id}/cancelar', [ReservaController::class, 'cancel']);
+    Route::post('reservas/{id}/no-show', [ReservaController::class, 'noShow']);
 });
 
 Route::prefix('v1')->middleware('auth.jwt')->group(function () {


### PR DESCRIPTION
## Summary
- add confirm, cancel, and no-show endpoints for reservations
- expose routes for reservation state transitions

## Testing
- `composer test` *(fails: require vendor/autoload.php)*
- `composer install` *(fails: requires GitHub token for dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689cf66b450c832f9f297bf7c5ad1c5c