### PR TITLE
feat: add cuentas split bill api

### DIFF
--- a/app/Http/Controllers/CuentaController.php
+++ b/app/Http/Controllers/CuentaController.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreCuentaRequest;
+use App\Http\Requests\UpdateCuentaRequest;
+use App\Http\Resources\CuentaResource;
+use App\Models\Cuenta;
+use App\Models\Pedido;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class CuentaController extends Controller
+{
+    /**
+     * @OA\Get(path="/v1/cuentas", summary="Listar cuentas", @OA\Response(response=200, description="OK"))
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $query = Cuenta::query();
+        if ($pedidoId = $request->query('pedido_id')) {
+            $query->where('pedido_id', $pedidoId);
+        }
+        if ($estado = $request->query('estado')) {
+            $query->where('estado', $estado);
+        }
+        if ($q = $request->query('q')) {
+            $query->where(function ($qr) use ($q) {
+                $qr->where('nombre', 'like', "%{$q}%")
+                   ->orWhere('notas', 'like', "%{$q}%");
+            });
+        }
+        $cuentas = $query->paginate();
+        return response()->json([
+            'data' => CuentaResource::collection($cuentas),
+            'meta' => ['current_page' => $cuentas->currentPage(), 'total' => $cuentas->total()],
+            'links' => ['self' => $request->fullUrl()],
+        ]);
+    }
+
+    /**
+     * @OA\Post(
+     *   path="/v1/cuentas",
+     *   summary="Crear cuenta",
+     *   @OA\RequestBody(required=true, @OA\JsonContent(required={"pedido_id","nombre"},
+     *       @OA\Property(property="pedido_id", type="string", format="uuid"),
+     *       @OA\Property(property="nombre", type="string", example="Cuenta 1"),
+     *       @OA\Property(property="notas", type="string", example="nota")
+     *   )),
+     *   @OA\Response(response=201, description="Cuenta creada")
+     * )
+     */
+    public function store(StoreCuentaRequest $request): JsonResponse
+    {
+        $data = $request->validated();
+        $pedido = Pedido::find($data['pedido_id']);
+        if (!$pedido || $pedido->estado === 'anulado') {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => ['pedido_id' => ['invalid']],
+            ], 422);
+        }
+        $cuenta = DB::transaction(fn () => Cuenta::create($data));
+        return response()->json(['data' => new CuentaResource($cuenta)], 201);
+    }
+
+    /**
+     * @OA\Get(path="/v1/cuentas/{id}", summary="Mostrar cuenta", @OA\Parameter(name="id", in="path", required=true, schema=@OA\Schema(type="string")), @OA\Response(response=200, description="OK"))
+     */
+    public function show(Cuenta $cuenta): JsonResponse
+    {
+        return response()->json(['data' => new CuentaResource($cuenta->load('items'))]);
+    }
+
+    /**
+     * @OA\Put(path="/v1/cuentas/{id}", summary="Actualizar cuenta", @OA\Parameter(name="id", in="path", required=true, schema=@OA\Schema(type="string")), @OA\Response(response=200, description="OK"))
+     */
+    public function update(UpdateCuentaRequest $request, Cuenta $cuenta): JsonResponse
+    {
+        if ($cuenta->estado !== 'abierta' && !$request->filled('estado')) {
+            return response()->json([
+                'error' => 'Conflict',
+                'message' => 'Cuenta no editable',
+            ], 409);
+        }
+        $data = $request->validated();
+        return DB::transaction(function () use ($cuenta, $data) {
+            if (($data['estado'] ?? null) === 'cerrada' && $cuenta->items()->count() === 0) {
+                return response()->json([
+                    'error' => 'Validation',
+                    'fields' => ['estado' => ['sin_items']],
+                ], 422);
+            }
+            $cuenta->update($data);
+            return response()->json(['data' => new CuentaResource($cuenta)]);
+        });
+    }
+
+    /**
+     * @OA\Delete(path="/v1/cuentas/{id}", summary="Eliminar cuenta", @OA\Parameter(name="id", in="path", required=true, schema=@OA\Schema(type="string")), @OA\Response(response=200, description="OK"))
+     */
+    public function destroy(Cuenta $cuenta): JsonResponse
+    {
+        if ($cuenta->estado === 'cerrada') {
+            return response()->json([
+                'error' => 'Validation',
+                'message' => 'No se puede eliminar una cuenta cerrada',
+            ], 422);
+        }
+        return DB::transaction(function () use ($cuenta) {
+            $cuenta->estado = 'anulada';
+            $cuenta->save();
+            $cuenta->items()->delete();
+            $cuenta->delete();
+            return response()->json(['data' => true]);
+        });
+    }
+}

--- a/app/Http/Controllers/CuentaItemController.php
+++ b/app/Http/Controllers/CuentaItemController.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\UpsertCuentaItemsRequest;
+use App\Http\Resources\CuentaResource;
+use App\Models\Cuenta;
+use App\Models\CuentaItem;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+
+class CuentaItemController extends Controller
+{
+    /**
+     * @OA\Post(
+     *   path="/v1/cuentas/{id}/items",
+     *   summary="Asignar items a la cuenta",
+     *   @OA\Parameter(name="id", in="path", required=true, schema=@OA\Schema(type="string")),
+     *   @OA\RequestBody(required=true, @OA\JsonContent(
+     *       @OA\Property(property="items", type="array", @OA\Items(
+     *           @OA\Property(property="pedido_item_id", type="string", format="uuid"),
+     *           @OA\Property(property="cantidad", type="number", example=1.5),
+     *           @OA\Property(property="monto", type="number", example=10.00)
+     *       ))
+     *   )),
+     *   @OA\Response(response=200, description="OK")
+     * )
+     */
+    public function store(UpsertCuentaItemsRequest $request, string $id): JsonResponse
+    {
+        return DB::transaction(function () use ($request, $id) {
+            $cuenta = Cuenta::lockForUpdate()->findOrFail($id);
+            if ($cuenta->estado !== 'abierta') {
+                return response()->json([
+                    'error' => 'Validation',
+                    'message' => 'Cuenta no abierta',
+                ], 422);
+            }
+            $pedidoId = $cuenta->pedido_id;
+            foreach ($request->input('items') as $entry) {
+                $pi = DB::table('pedido_items')->where('id', $entry['pedido_item_id'])->first();
+                if (!$pi || $pi->pedido_id !== $pedidoId) {
+                    return response()->json([
+                        'error' => 'Validation',
+                        'fields' => ['pedido_item_id' => ['invalid']],
+                    ], 422);
+                }
+                $assigned = DB::table('cuenta_items as ci')
+                    ->join('cuentas as c', 'c.id', '=', 'ci.cuenta_id')
+                    ->where('ci.pedido_item_id', $pi->id)
+                    ->where('c.pedido_id', $pedidoId)
+                    ->where('c.estado', '<>', 'anulada')
+                    ->where('ci.cuenta_id', '<>', $cuenta->id)
+                    ->selectRaw('COALESCE(SUM(ci.cantidad),0) as cant, COALESCE(SUM(ci.monto),0) as monto')
+                    ->first();
+                $cantRem = $pi->cantidad - $assigned->cant;
+                $montoRem = ($pi->cantidad * $pi->precio_unit) - $assigned->monto;
+                $cantidad = $entry['cantidad'] ?? null;
+                $monto = $entry['monto'] ?? null;
+                if (is_null($cantidad) && !is_null($monto)) {
+                    $cantidad = round($monto / $pi->precio_unit, 4);
+                }
+                if (is_null($monto) && !is_null($cantidad)) {
+                    $monto = round($cantidad * $pi->precio_unit, 2);
+                }
+                if ($cantidad > $cantRem + 0.0001 || $monto > $montoRem + 0.01) {
+                    return response()->json([
+                        'error' => 'Validation',
+                        'fields' => ['items' => ['remanente']]
+                    ], 422);
+                }
+                $impuesto = round($monto * ($pi->impuesto_porcentaje / 100), 2);
+                CuentaItem::updateOrCreate(
+                    ['cuenta_id' => $cuenta->id, 'pedido_item_id' => $pi->id],
+                    [
+                        'cantidad' => $cantidad,
+                        'monto' => $monto,
+                        'impuesto_monto' => $impuesto,
+                        'notas' => $entry['notas'] ?? null,
+                    ]
+                );
+            }
+            $totals = $cuenta->items()
+                ->selectRaw('COALESCE(SUM(monto),0) as subtotal, COALESCE(SUM(impuesto_monto),0) as impuesto')
+                ->first();
+            $cuenta->subtotal = $totals->subtotal;
+            $cuenta->impuesto = $totals->impuesto;
+            $cuenta->total = round($cuenta->subtotal - $cuenta->descuento + $cuenta->impuesto, 2);
+            $cuenta->save();
+            $cuenta->load('items');
+            return response()->json(['data' => new CuentaResource($cuenta)]);
+        });
+    }
+}

--- a/app/Http/Requests/StoreCuentaRequest.php
+++ b/app/Http/Requests/StoreCuentaRequest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreCuentaRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'pedido_id' => ['required','uuid','exists:pedidos,id'],
+            'nombre' => ['required','string','max:60'],
+            'notas' => ['nullable','string','max:255'],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateCuentaRequest.php
+++ b/app/Http/Requests/UpdateCuentaRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateCuentaRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'nombre' => ['required','string','max:60'],
+            'notas' => ['nullable','string','max:255'],
+            'descuento' => ['nullable','numeric','min:0'],
+            'estado' => ['nullable','in:abierta,cerrada,anulada'],
+        ];
+    }
+}

--- a/app/Http/Requests/UpsertCuentaItemsRequest.php
+++ b/app/Http/Requests/UpsertCuentaItemsRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Validator;
+
+class UpsertCuentaItemsRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'items' => ['required','array','min:1'],
+            'items.*.pedido_item_id' => ['required','uuid','exists:pedido_items,id'],
+            'items.*.cantidad' => ['nullable','numeric','min:0.0001'],
+            'items.*.monto' => ['nullable','numeric','min:0.01'],
+            'items.*.notas' => ['nullable','string','max:255'],
+        ];
+    }
+
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $v) {
+            foreach ($this->input('items', []) as $idx => $item) {
+                if (!isset($item['cantidad']) && !isset($item['monto'])) {
+                    $v->errors()->add("items.$idx.cantidad", 'required_without:monto');
+                }
+            }
+        });
+    }
+}

--- a/app/Http/Resources/CuentaItemResource.php
+++ b/app/Http/Resources/CuentaItemResource.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class CuentaItemResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'cuenta_id' => $this->cuenta_id,
+            'pedido_item_id' => $this->pedido_item_id,
+            'cantidad' => (float) $this->cantidad,
+            'monto' => (float) $this->monto,
+            'impuesto_monto' => (float) $this->impuesto_monto,
+            'notas' => $this->notas,
+            'created_at' => $this->created_at,
+        ];
+    }
+}

--- a/app/Http/Resources/CuentaResource.php
+++ b/app/Http/Resources/CuentaResource.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class CuentaResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'pedido_id' => $this->pedido_id,
+            'nombre' => $this->nombre,
+            'notas' => $this->notas,
+            'subtotal' => (float) $this->subtotal,
+            'descuento' => (float) $this->descuento,
+            'impuesto' => (float) $this->impuesto,
+            'total' => (float) $this->total,
+            'estado' => $this->estado,
+            'items' => CuentaItemResource::collection($this->whenLoaded('items')),
+            'created_at' => $this->created_at,
+        ];
+    }
+}

--- a/app/Models/Cuenta.php
+++ b/app/Models/Cuenta.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Cuenta extends Model
+{
+    use HasUuids, SoftDeletes;
+
+    protected $fillable = [
+        'pedido_id',
+        'nombre',
+        'notas',
+        'subtotal',
+        'descuento',
+        'impuesto',
+        'total',
+        'estado',
+        'created_by',
+    ];
+
+    public function pedido(): BelongsTo
+    {
+        return $this->belongsTo(Pedido::class);
+    }
+
+    public function items(): HasMany
+    {
+        return $this->hasMany(CuentaItem::class);
+    }
+}

--- a/app/Models/CuentaItem.php
+++ b/app/Models/CuentaItem.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class CuentaItem extends Model
+{
+    use HasUuids;
+
+    protected $fillable = [
+        'cuenta_id',
+        'pedido_item_id',
+        'cantidad',
+        'monto',
+        'impuesto_monto',
+        'notas',
+    ];
+
+    public function cuenta(): BelongsTo
+    {
+        return $this->belongsTo(Cuenta::class);
+    }
+
+    public function pedidoItem(): BelongsTo
+    {
+        return $this->belongsTo(PedidoItem::class);
+    }
+}

--- a/database/migrations/2024_08_14_000005_create_cuentas_table.php
+++ b/database/migrations/2024_08_14_000005_create_cuentas_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('cuentas', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('pedido_id')->index();
+            $table->string('nombre',60)->default('Cuenta');
+            $table->string('notas',255)->nullable();
+            $table->decimal('subtotal',14,2)->default(0);
+            $table->decimal('descuento',14,2)->default(0);
+            $table->decimal('impuesto',14,2)->default(0);
+            $table->decimal('total',14,2)->default(0);
+            $table->enum('estado',["abierta","cerrada","anulada"])->default('abierta')->index();
+            $table->uuid('created_by')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+            $table->index(['pedido_id','estado']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('cuentas');
+    }
+};

--- a/database/migrations/2024_08_14_000006_create_cuenta_items_table.php
+++ b/database/migrations/2024_08_14_000006_create_cuenta_items_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('cuenta_items', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('cuenta_id')->index();
+            $table->foreignUuid('pedido_item_id')->index();
+            $table->decimal('cantidad',12,4);
+            $table->decimal('monto',12,2);
+            $table->decimal('impuesto_monto',12,2)->default(0);
+            $table->string('notas',255)->nullable();
+            $table->timestamps();
+            $table->unique(['cuenta_id','pedido_item_id']);
+            $table->index(['pedido_item_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('cuenta_items');
+    }
+};

--- a/database/seeders/CuentaSeeder.php
+++ b/database/seeders/CuentaSeeder.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Pedido;
+use App\Models\PedidoItem;
+use App\Models\Cuenta;
+use App\Models\CuentaItem;
+
+class CuentaSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $pedido = Pedido::create([
+            'origen' => 'salon',
+            'estado' => 'abierto',
+            'subtotal' => 0,
+            'descuento' => 0,
+            'impuesto' => 0,
+            'total' => 0,
+        ]);
+        $item1 = PedidoItem::create([
+            'pedido_id' => $pedido->id,
+            'producto_id' => (string)\Illuminate\Support\Str::uuid(),
+            'nombre' => 'Item 1',
+            'cantidad' => 2,
+            'precio_unit' => 10,
+            'impuesto_porcentaje' => 0,
+            'estado' => 'pendiente',
+            'estacion' => 'cocina',
+            'orden_sec' => 1,
+        ]);
+        $item2 = PedidoItem::create([
+            'pedido_id' => $pedido->id,
+            'producto_id' => (string)\Illuminate\Support\Str::uuid(),
+            'nombre' => 'Item 2',
+            'cantidad' => 1,
+            'precio_unit' => 20,
+            'impuesto_porcentaje' => 0,
+            'estado' => 'pendiente',
+            'estacion' => 'cocina',
+            'orden_sec' => 2,
+        ]);
+        $cuenta1 = Cuenta::create(['pedido_id' => $pedido->id, 'nombre' => 'Cuenta A']);
+        $cuenta2 = Cuenta::create(['pedido_id' => $pedido->id, 'nombre' => 'Cuenta B']);
+        CuentaItem::create([
+            'cuenta_id' => $cuenta1->id,
+            'pedido_item_id' => $item1->id,
+            'cantidad' => 1,
+            'monto' => 10,
+            'impuesto_monto' => 0,
+        ]);
+        CuentaItem::create([
+            'cuenta_id' => $cuenta2->id,
+            'pedido_item_id' => $item2->id,
+            'cantidad' => 1,
+            'monto' => 20,
+            'impuesto_monto' => 0,
+        ]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -25,6 +25,8 @@ use App\Http\Controllers\PagoProveedorController;
 use App\Http\Controllers\MenuController;
 use App\Http\Controllers\PedidoController;
 use App\Http\Controllers\ReservaController;
+use App\Http\Controllers\CuentaController;
+use App\Http\Controllers\CuentaItemController;
 
 Route::prefix('v1/auth')->group(function () {
     Route::post('/login', [AuthController::class, 'login']);
@@ -39,6 +41,8 @@ Route::get('/v1/menu', [MenuController::class, 'index']);
 
 Route::prefix('v1')->middleware('idempotency')->group(function () {
     Route::apiResource('pedidos', PedidoController::class);
+    Route::apiResource('cuentas', CuentaController::class);
+    Route::post('cuentas/{cuenta}/items', [CuentaItemController::class, 'store']);
 });
 
 Route::prefix('v1')->group(function () {

--- a/tests/Feature/CuentaTest.php
+++ b/tests/Feature/CuentaTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Pedido;
+use App\Models\PedidoItem;
+use App\Models\Cuenta;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CuentaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createPedidoConItem(): array
+    {
+        $pedido = Pedido::create(['origen' => 'salon']);
+        $item = PedidoItem::create([
+            'pedido_id' => $pedido->id,
+            'producto_id' => (string)\Illuminate\Support\Str::uuid(),
+            'nombre' => 'Item',
+            'cantidad' => 2,
+            'precio_unit' => 10,
+            'impuesto_porcentaje' => 0,
+            'estado' => 'pendiente',
+            'estacion' => 'cocina',
+            'orden_sec' => 1,
+        ]);
+        return [$pedido, $item];
+    }
+
+    public function test_create_cuenta(): void
+    {
+        $pedido = Pedido::create(['origen' => 'salon']);
+        $response = $this->postJson('/api/v1/cuentas', [
+            'pedido_id' => $pedido->id,
+            'nombre' => 'Cuenta 1'
+        ]);
+        $response->assertCreated();
+        $this->assertDatabaseCount('cuentas', 1);
+    }
+
+    public function test_create_cuenta_validation_error(): void
+    {
+        $response = $this->postJson('/api/v1/cuentas', []);
+        $response->assertStatus(422);
+    }
+
+    public function test_list_cuentas(): void
+    {
+        $pedido = Pedido::create(['origen' => 'salon']);
+        Cuenta::create(['pedido_id' => $pedido->id, 'nombre' => 'Cuenta 1']);
+        $response = $this->getJson('/api/v1/cuentas');
+        $response->assertOk();
+    }
+
+    public function test_show_cuenta(): void
+    {
+        $pedido = Pedido::create(['origen' => 'salon']);
+        $cuenta = Cuenta::create(['pedido_id' => $pedido->id, 'nombre' => 'Cuenta 1']);
+        $response = $this->getJson('/api/v1/cuentas/' . $cuenta->id);
+        $response->assertOk();
+    }
+
+    public function test_update_cuenta(): void
+    {
+        $pedido = Pedido::create(['origen' => 'salon']);
+        $cuenta = Cuenta::create(['pedido_id' => $pedido->id, 'nombre' => 'Cuenta 1']);
+        $response = $this->putJson('/api/v1/cuentas/' . $cuenta->id, [
+            'nombre' => 'Cuenta X',
+        ]);
+        $response->assertOk();
+        $this->assertDatabaseHas('cuentas', ['id' => $cuenta->id, 'nombre' => 'Cuenta X']);
+    }
+
+    public function test_delete_cuenta(): void
+    {
+        $pedido = Pedido::create(['origen' => 'salon']);
+        $cuenta = Cuenta::create(['pedido_id' => $pedido->id, 'nombre' => 'Cuenta 1']);
+        $response = $this->deleteJson('/api/v1/cuentas/' . $cuenta->id);
+        $response->assertOk();
+        $this->assertSoftDeleted('cuentas', ['id' => $cuenta->id]);
+    }
+
+    public function test_asignar_item_por_cantidad(): void
+    {
+        [$pedido, $item] = $this->createPedidoConItem();
+        $cuenta = Cuenta::create(['pedido_id' => $pedido->id, 'nombre' => 'Cuenta A']);
+        $response = $this->postJson('/api/v1/cuentas/' . $cuenta->id . '/items', [
+            'items' => [
+                ['pedido_item_id' => $item->id, 'cantidad' => 1]
+            ]
+        ]);
+        $response->assertOk();
+        $this->assertDatabaseHas('cuenta_items', ['cuenta_id' => $cuenta->id, 'pedido_item_id' => $item->id]);
+    }
+
+    public function test_asignar_item_remanente_insuficiente(): void
+    {
+        [$pedido, $item] = $this->createPedidoConItem();
+        $cuenta = Cuenta::create(['pedido_id' => $pedido->id, 'nombre' => 'Cuenta A']);
+        $this->postJson('/api/v1/cuentas/' . $cuenta->id . '/items', [
+            'items' => [
+                ['pedido_item_id' => $item->id, 'cantidad' => 2]
+            ]
+        ]);
+        $response = $this->postJson('/api/v1/cuentas/' . $cuenta->id . '/items', [
+            'items' => [
+                ['pedido_item_id' => $item->id, 'cantidad' => 1]
+            ]
+        ]);
+        $response->assertStatus(422);
+    }
+
+    public function test_cerrar_cuenta_sin_items_error(): void
+    {
+        $pedido = Pedido::create(['origen' => 'salon']);
+        $cuenta = Cuenta::create(['pedido_id' => $pedido->id, 'nombre' => 'Cuenta A']);
+        $response = $this->putJson('/api/v1/cuentas/' . $cuenta->id, [
+            'nombre' => 'Cuenta A',
+            'estado' => 'cerrada'
+        ]);
+        $response->assertStatus(422);
+    }
+
+    public function test_cerrar_cuenta_ok(): void
+    {
+        [$pedido, $item] = $this->createPedidoConItem();
+        $cuenta = Cuenta::create(['pedido_id' => $pedido->id, 'nombre' => 'Cuenta A']);
+        $this->postJson('/api/v1/cuentas/' . $cuenta->id . '/items', [
+            'items' => [
+                ['pedido_item_id' => $item->id, 'cantidad' => 1]
+            ]
+        ]);
+        $response = $this->putJson('/api/v1/cuentas/' . $cuenta->id, [
+            'nombre' => 'Cuenta A',
+            'estado' => 'cerrada'
+        ]);
+        $response->assertOk();
+        $this->assertDatabaseHas('cuentas', ['id' => $cuenta->id, 'estado' => 'cerrada']);
+    }
+}


### PR DESCRIPTION
## Summary
- implement cuentas and cuenta_items migrations
- add models, resources, requests and controllers for split bill
- expose REST routes with OpenAPI docs and add feature tests

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_689e727f9c68832fa8db3f9fc760b5ae