### PR TITLE
feat(sri): basic SRI secuencia module

### DIFF
--- a/app/Http/Controllers/Sri/SecuenciaController.php
+++ b/app/Http/Controllers/Sri/SecuenciaController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers\Sri;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Sri\NextSecuenciaRequest;
+use App\Http\Resources\Sri\SecuenciaResource;
+use App\Services\Sri\SecuenciaService;
+
+class SecuenciaController extends Controller
+{
+    public function __construct(private SecuenciaService $service)
+    {
+    }
+
+    public function next(NextSecuenciaRequest $request)
+    {
+        $data = $request->validated();
+        $numero = $this->service->next(
+            $data['emisor_id'],
+            $data['establecimiento'],
+            $data['punto'],
+            $data['tipo']
+        );
+
+        return new SecuenciaResource($numero);
+    }
+}

--- a/app/Http/Requests/Sri/NextSecuenciaRequest.php
+++ b/app/Http/Requests/Sri/NextSecuenciaRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Requests\Sri;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class NextSecuenciaRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'emisor_id' => ['required','uuid'],
+            'establecimiento' => ['required','string','size:3'],
+            'punto' => ['required','string','size:3'],
+            'tipo' => ['required','in:01,04,05,06,07'],
+        ];
+    }
+}

--- a/app/Http/Resources/Sri/SecuenciaResource.php
+++ b/app/Http/Resources/Sri/SecuenciaResource.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Resources\Sri;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin \App\Models\Sri\Secuencia */
+class SecuenciaResource extends JsonResource
+{
+    public function toArray($request)
+    {
+        return [
+            'secuencial' => $this->resource,
+        ];
+    }
+}

--- a/app/Models/Sri/Certificado.php
+++ b/app/Models/Sri/Certificado.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models\Sri;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+class Certificado extends Model
+{
+    use HasFactory, SoftDeletes, HasUuids;
+
+    protected $table = 'sri_certificados';
+
+    protected $fillable = [
+        'emisor_id',
+        'alias',
+        'p12_base64',
+        'p12_password',
+        'valido_desde',
+        'valido_hasta',
+        'activo',
+    ];
+
+    public function emisor()
+    {
+        return $this->belongsTo(Emisor::class);
+    }
+}

--- a/app/Models/Sri/Comprobante.php
+++ b/app/Models/Sri/Comprobante.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models\Sri;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+class Comprobante extends Model
+{
+    use HasFactory, SoftDeletes, HasUuids;
+
+    protected $table = 'sri_comprobantes';
+
+    protected $fillable = [
+        'tipo','emisor_id','establecimiento','punto_emision','secuencial','numero','fecha_emision',
+        'clave_acceso','ambiente','tipo_emision','estado','fuente','fuente_id','receptor_identificacion',
+        'receptor_razon_social','total_sin_impuestos','total_descuento','propina','importe_total','moneda',
+        'xml_generado','xml_firmado','nro_autorizacion','fecha_autorizacion','ride_pdf_path','ultimo_error',
+        'certificado_id','reintentos_envio','reintentos_autorizacion','created_by'
+    ];
+
+    public function items()
+    {
+        return $this->hasMany(ComprobanteItem::class);
+    }
+}

--- a/app/Models/Sri/ComprobanteItem.php
+++ b/app/Models/Sri/ComprobanteItem.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models\Sri;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+class ComprobanteItem extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $table = 'sri_comprobante_items';
+
+    protected $fillable = [
+        'comprobante_id','codigo_principal','descripcion','cantidad','precio_unit','descuento',
+        'impuesto_codigo','impuesto_tarifa','impuesto_base','impuesto_valor','orden'
+    ];
+
+    public function comprobante()
+    {
+        return $this->belongsTo(Comprobante::class);
+    }
+}

--- a/app/Models/Sri/Emisor.php
+++ b/app/Models/Sri/Emisor.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models\Sri;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+class Emisor extends Model
+{
+    use HasFactory, SoftDeletes, HasUuids;
+
+    protected $table = 'sri_emisores';
+
+    protected $fillable = [
+        'ruc',
+        'razon_social',
+        'nombre_comercial',
+        'contribuyente_especial',
+        'obligado_contabilidad',
+        'direccion_matriz',
+        'ambiente',
+        'tipo_emision',
+        'email_contacto',
+        'telefono',
+    ];
+
+    public function establecimientos()
+    {
+        return $this->hasMany(Establecimiento::class);
+    }
+}

--- a/app/Models/Sri/Establecimiento.php
+++ b/app/Models/Sri/Establecimiento.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models\Sri;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+class Establecimiento extends Model
+{
+    use HasFactory, SoftDeletes, HasUuids;
+
+    protected $table = 'sri_establecimientos';
+
+    protected $fillable = [
+        'emisor_id',
+        'codigo',
+        'direccion',
+        'nombre',
+    ];
+
+    public function emisor()
+    {
+        return $this->belongsTo(Emisor::class);
+    }
+
+    public function puntos()
+    {
+        return $this->hasMany(PuntoEmision::class);
+    }
+}

--- a/app/Models/Sri/Log.php
+++ b/app/Models/Sri/Log.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models\Sri;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+class Log extends Model
+{
+    use HasFactory, HasUuids;
+
+    public $timestamps = false;
+    protected $table = 'sri_logs';
+
+    protected $fillable = [
+        'comprobante_id','fase','request_payload','response_payload','http_code','mensaje','error','created_at'
+    ];
+
+    public function comprobante()
+    {
+        return $this->belongsTo(Comprobante::class);
+    }
+}

--- a/app/Models/Sri/PuntoEmision.php
+++ b/app/Models/Sri/PuntoEmision.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models\Sri;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+class PuntoEmision extends Model
+{
+    use HasFactory, SoftDeletes, HasUuids;
+
+    protected $table = 'sri_puntos_emision';
+
+    protected $fillable = [
+        'establecimiento_id',
+        'codigo',
+        'sec_hasta',
+    ];
+
+    public function establecimiento()
+    {
+        return $this->belongsTo(Establecimiento::class);
+    }
+
+    public function secuencias()
+    {
+        return $this->hasMany(Secuencia::class);
+    }
+}

--- a/app/Models/Sri/Secuencia.php
+++ b/app/Models/Sri/Secuencia.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models\Sri;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+class Secuencia extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $table = 'sri_secuencias';
+
+    protected $fillable = [
+        'punto_emision_id',
+        'tipo',
+        'actual',
+        'bloqueado',
+    ];
+
+    public function punto()
+    {
+        return $this->belongsTo(PuntoEmision::class, 'punto_emision_id');
+    }
+}

--- a/app/Services/Sri/SecuenciaService.php
+++ b/app/Services/Sri/SecuenciaService.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Services\Sri;
+
+use App\Models\Sri\Secuencia;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+
+class SecuenciaService
+{
+    /**
+     * Obtiene y bloquea la siguiente secuencia.
+     */
+    public function next(string $emisorId, string $establecimiento, string $punto, string $tipo): int
+    {
+        return DB::transaction(function () use ($emisorId, $establecimiento, $punto, $tipo) {
+            $row = DB::table('sri_secuencias as s')
+                ->join('sri_puntos_emision as pe', 'pe.id', '=', 's.punto_emision_id')
+                ->join('sri_establecimientos as e', 'e.id', '=', 'pe.establecimiento_id')
+                ->where('e.emisor_id', $emisorId)
+                ->where('e.codigo', $establecimiento)
+                ->where('pe.codigo', $punto)
+                ->where('s.tipo', $tipo)
+                ->lockForUpdate()
+                ->select('s.id','s.actual','pe.sec_hasta')
+                ->first();
+
+            if (!$row) {
+                throw new RuntimeException('Secuencia no encontrada');
+            }
+
+            $nuevo = $row->actual + 1;
+            if ($nuevo > $row->sec_hasta) {
+                throw new RuntimeException('Secuencia agotada');
+            }
+
+            DB::table('sri_secuencias')->where('id', $row->id)->update(['actual' => $nuevo, 'updated_at' => now()]);
+
+            return $nuevo;
+        });
+    }
+}

--- a/database/migrations/2025_08_18_000001_create_sri_emisores_table.php
+++ b/database/migrations/2025_08_18_000001_create_sri_emisores_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('sri_emisores', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->char('ruc', 13)->unique();
+            $table->string('razon_social', 200);
+            $table->string('nombre_comercial', 200)->nullable();
+            $table->string('contribuyente_especial', 10)->nullable();
+            $table->boolean('obligado_contabilidad')->default(false);
+            $table->string('direccion_matriz', 255);
+            $table->enum('ambiente', ['1', '2'])->default('1');
+            $table->enum('tipo_emision', ['1', '2'])->default('1');
+            $table->string('email_contacto', 150)->nullable();
+            $table->string('telefono', 50)->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('sri_emisores');
+    }
+};

--- a/database/migrations/2025_08_18_000002_create_sri_establecimientos_table.php
+++ b/database/migrations/2025_08_18_000002_create_sri_establecimientos_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('sri_establecimientos', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('emisor_id');
+            $table->char('codigo', 3);
+            $table->string('direccion', 255);
+            $table->string('nombre', 150)->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->unique(['emisor_id', 'codigo']);
+            $table->foreign('emisor_id')->references('id')->on('sri_emisores');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('sri_establecimientos');
+    }
+};

--- a/database/migrations/2025_08_18_000003_create_sri_puntos_emision_table.php
+++ b/database/migrations/2025_08_18_000003_create_sri_puntos_emision_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('sri_puntos_emision', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('establecimiento_id');
+            $table->char('codigo', 3);
+            $table->unsignedInteger('sec_hasta')->default(999999999);
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->unique(['establecimiento_id', 'codigo']);
+            $table->foreign('establecimiento_id')->references('id')->on('sri_establecimientos');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('sri_puntos_emision');
+    }
+};

--- a/database/migrations/2025_08_18_000004_create_sri_secuencias_table.php
+++ b/database/migrations/2025_08_18_000004_create_sri_secuencias_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('sri_secuencias', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('punto_emision_id');
+            $table->enum('tipo', ['01','04','05','06','07']);
+            $table->unsignedInteger('actual');
+            $table->boolean('bloqueado')->default(false);
+            $table->timestamps();
+
+            $table->unique(['punto_emision_id', 'tipo']);
+            $table->foreign('punto_emision_id')->references('id')->on('sri_puntos_emision');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('sri_secuencias');
+    }
+};

--- a/database/migrations/2025_08_18_000005_create_sri_certificados_table.php
+++ b/database/migrations/2025_08_18_000005_create_sri_certificados_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('sri_certificados', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('emisor_id');
+            $table->string('alias', 120);
+            $table->longText('p12_base64');
+            $table->string('p12_password', 200);
+            $table->date('valido_desde')->nullable();
+            $table->date('valido_hasta')->nullable();
+            $table->boolean('activo')->default(true);
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->foreign('emisor_id')->references('id')->on('sri_emisores');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('sri_certificados');
+    }
+};

--- a/database/migrations/2025_08_18_000006_create_sri_comprobantes_table.php
+++ b/database/migrations/2025_08_18_000006_create_sri_comprobantes_table.php
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('sri_comprobantes', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->enum('tipo', ['01','04','05','06','07']);
+            $table->uuid('emisor_id');
+            $table->char('establecimiento', 3);
+            $table->char('punto_emision', 3);
+            $table->unsignedInteger('secuencial');
+            $table->string('numero', 17)->index();
+            $table->date('fecha_emision');
+            $table->char('clave_acceso', 49)->unique();
+            $table->enum('ambiente', ['1','2']);
+            $table->enum('tipo_emision', ['1','2']);
+            $table->enum('estado', ['generado','firmado','enviado','autorizado','no_autorizado','rechazado','error','anulado'])->default('generado')->index();
+            $table->enum('fuente', ['factura_venta','nota_credito_venta','nota_debito_venta','guia_remision','retencion','manual'])->default('manual');
+            $table->uuid('fuente_id')->nullable();
+            $table->string('receptor_identificacion', 20);
+            $table->string('receptor_razon_social', 200);
+            $table->decimal('total_sin_impuestos', 14, 2);
+            $table->decimal('total_descuento', 14, 2)->default(0);
+            $table->decimal('propina', 14, 2)->default(0);
+            $table->decimal('importe_total', 14, 2);
+            $table->char('moneda', 3)->default('USD');
+            $table->longText('xml_generado')->nullable();
+            $table->longText('xml_firmado')->nullable();
+            $table->string('nro_autorizacion', 49)->nullable();
+            $table->dateTime('fecha_autorizacion')->nullable();
+            $table->string('ride_pdf_path', 255)->nullable();
+            $table->text('ultimo_error')->nullable();
+            $table->uuid('certificado_id')->nullable();
+            $table->unsignedInteger('reintentos_envio')->default(0);
+            $table->unsignedInteger('reintentos_autorizacion')->default(0);
+            $table->uuid('created_by')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index(['clave_acceso', 'estado', 'fecha_emision']);
+            $table->foreign('emisor_id')->references('id')->on('sri_emisores');
+            $table->foreign('certificado_id')->references('id')->on('sri_certificados');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('sri_comprobantes');
+    }
+};

--- a/database/migrations/2025_08_18_000007_create_sri_comprobante_items_table.php
+++ b/database/migrations/2025_08_18_000007_create_sri_comprobante_items_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('sri_comprobante_items', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('comprobante_id')->index();
+            $table->string('codigo_principal', 50);
+            $table->string('descripcion', 300);
+            $table->decimal('cantidad', 12, 4);
+            $table->decimal('precio_unit', 12, 6);
+            $table->decimal('descuento', 12, 6)->default(0);
+            $table->enum('impuesto_codigo', ['2','3','5','6','7'])->nullable();
+            $table->decimal('impuesto_tarifa', 5, 2)->nullable();
+            $table->decimal('impuesto_base', 12, 6)->nullable();
+            $table->decimal('impuesto_valor', 12, 6)->nullable();
+            $table->unsignedInteger('orden');
+            $table->timestamps();
+
+            $table->foreign('comprobante_id')->references('id')->on('sri_comprobantes');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('sri_comprobante_items');
+    }
+};

--- a/database/migrations/2025_08_18_000008_create_sri_logs_table.php
+++ b/database/migrations/2025_08_18_000008_create_sri_logs_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('sri_logs', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('comprobante_id')->index();
+            $table->enum('fase', ['generar','firmar','enviar','autorizar','reenviar','consultar']);
+            $table->longText('request_payload')->nullable();
+            $table->longText('response_payload')->nullable();
+            $table->integer('http_code')->nullable();
+            $table->string('mensaje', 300)->nullable();
+            $table->text('error')->nullable();
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->foreign('comprobante_id')->references('id')->on('sri_comprobantes');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('sri_logs');
+    }
+};

--- a/database/seeders/SriSeeder.php
+++ b/database/seeders/SriSeeder.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\DB;
+
+class SriSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $emisorId = Str::uuid();
+        DB::table('sri_emisores')->insert([
+            'id' => $emisorId,
+            'ruc' => '9999999999999',
+            'razon_social' => 'Demo SRI',
+            'direccion_matriz' => 'Quito',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $estabId = Str::uuid();
+        DB::table('sri_establecimientos')->insert([
+            'id' => $estabId,
+            'emisor_id' => $emisorId,
+            'codigo' => '001',
+            'direccion' => 'Quito',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $puntoId = Str::uuid();
+        DB::table('sri_puntos_emision')->insert([
+            'id' => $puntoId,
+            'establecimiento_id' => $estabId,
+            'codigo' => '001',
+            'sec_hasta' => 999999999,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        foreach (['01','04','05','06','07'] as $tipo) {
+            DB::table('sri_secuencias')->insert([
+                'id' => Str::uuid(),
+                'punto_emision_id' => $puntoId,
+                'tipo' => $tipo,
+                'actual' => 0,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+
+        DB::table('sri_certificados')->insert([
+            'id' => Str::uuid(),
+            'emisor_id' => $emisorId,
+            'alias' => 'demo',
+            'p12_base64' => '',
+            'p12_password' => encrypt(''),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -30,6 +30,7 @@ use App\Http\Controllers\CuentaItemController;
 use App\Http\Controllers\FacturaController;
 use App\Http\Controllers\CxcVentaController;
 use App\Http\Controllers\NotaCreditoController;
+use App\Http\Controllers\Sri\SecuenciaController;
 
 Route::prefix('v1/auth')->group(function () {
     Route::post('/login', [AuthController::class, 'login']);
@@ -186,6 +187,7 @@ Route::prefix('v1')->middleware('auth.jwt')->group(function () {
         Route::post('/ventas/notas-credito/{id}/anular', [NotaCreditoController::class,'anular']);
     });
 
+    Route::post('/sri/secuencias/next',[SecuenciaController::class,'next']);
     Route::get('/estado-suscripcion', SubscriptionStatusController::class);
 });
 

--- a/tests/Feature/Sri/SecuenciaNextTest.php
+++ b/tests/Feature/Sri/SecuenciaNextTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Feature\Sri;
+
+use App\Models\Sri\{Emisor, Establecimiento, PuntoEmision, Secuencia};
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class SecuenciaNextTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutMiddleware();
+    }
+
+    private function baseData(): array
+    {
+        $emisor = Emisor::create([
+            'id' => Str::uuid(),
+            'ruc' => '0123456789001',
+            'razon_social' => 'Demo',
+            'direccion_matriz' => 'Quito',
+        ]);
+
+        $estab = Establecimiento::create([
+            'id' => Str::uuid(),
+            'emisor_id' => $emisor->id,
+            'codigo' => '001',
+            'direccion' => 'Dir',
+        ]);
+
+        $punto = PuntoEmision::create([
+            'id' => Str::uuid(),
+            'establecimiento_id' => $estab->id,
+            'codigo' => '001',
+            'sec_hasta' => 999999999,
+        ]);
+
+        $secuencia = Secuencia::create([
+            'id' => Str::uuid(),
+            'punto_emision_id' => $punto->id,
+            'tipo' => '01',
+            'actual' => 1,
+        ]);
+
+        return [$emisor, $estab, $punto, $secuencia];
+    }
+
+    public function test_next_secuencial(): void
+    {
+        [$emisor] = $this->baseData();
+
+        $response = $this->postJson('/api/v1/sri/secuencias/next', [
+            'emisor_id' => $emisor->id,
+            'establecimiento' => '001',
+            'punto' => '001',
+            'tipo' => '01',
+        ]);
+
+        $response->assertOk()->assertJson(['data' => ['secuencial' => 2]]);
+    }
+
+    public function test_next_secuencial_not_found(): void
+    {
+        [$emisor] = $this->baseData();
+
+        $response = $this->postJson('/api/v1/sri/secuencias/next', [
+            'emisor_id' => $emisor->id,
+            'establecimiento' => '001',
+            'punto' => '001',
+            'tipo' => '04',
+        ]);
+
+        $response->assertStatus(500);
+    }
+}


### PR DESCRIPTION
## Summary
- add SRI tables migrations and seed data
- implement SecuenciaService with atomic next() and REST endpoint
- include feature tests for secuencia happy path and error

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a3330bb5b4832fb38af41c446fca0f