### PR TITLE
docs: actualizar listado de APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ Puedes importar el archivo `apis.json` en Postman para probar todos los endpoint
 | PUT | `/v1/pedidos/{id}` | Actualiza un pedido existente. |
 | DELETE | `/v1/pedidos/{id}` | Elimina un pedido. |
 
+## Cuentas
+| Método | Ruta | Descripción |
+| ------ | ---- | ----------- |
+| GET | `/v1/cuentas` | Lista todas las cuentas. |
+| POST | `/v1/cuentas` | Crea una nueva cuenta. |
+| GET | `/v1/cuentas/{id}` | Muestra la información de una cuenta. |
+| PUT | `/v1/cuentas/{id}` | Actualiza una cuenta existente. |
+| DELETE | `/v1/cuentas/{id}` | Elimina una cuenta. |
+| POST | `/v1/cuentas/{id}/items` | Agrega un item a la cuenta. |
+
 ## Reservas
 | Método | Ruta | Descripción |
 | ------ | ---- | ----------- |
@@ -207,8 +217,37 @@ Puedes importar el archivo `apis.json` en Postman para probar todos los endpoint
 | PUT | `/v1/mesas/{id}` | Actualiza una mesa. |
 | DELETE | `/v1/mesas/{id}` | Elimina una mesa. |
 
+### Ventas - Facturas
+| Método | Ruta | Descripción |
+| ------ | ---- | ----------- |
+| GET | `/v1/ventas/facturas` | Lista facturas de venta. |
+| POST | `/v1/ventas/facturas` | Crea una factura de venta. |
+| GET | `/v1/ventas/facturas/{id}` | Muestra una factura de venta. |
+| PUT | `/v1/ventas/facturas/{id}` | Actualiza una factura de venta. |
+| DELETE | `/v1/ventas/facturas/{id}` | Elimina una factura de venta. |
+| POST | `/v1/ventas/facturas/{id}/aprobar` | Aprueba una factura. |
+| POST | `/v1/ventas/facturas/{id}/anular` | Anula una factura. |
+
+### Cuentas por cobrar
+| Método | Ruta | Descripción |
+| ------ | ---- | ----------- |
+| GET | `/v1/cxc` | Lista cuentas por cobrar. |
+| GET | `/v1/cxc/{id}` | Muestra una cuenta por cobrar. |
+| POST | `/v1/cxc/pagos` | Registra un pago. |
+| GET | `/v1/cxc/{id}/pagos` | Lista los pagos de una cuenta por cobrar. |
+
+### Notas de crédito
+| Método | Ruta | Descripción |
+| ------ | ---- | ----------- |
+| GET | `/v1/ventas/notas-credito` | Lista notas de crédito. |
+| POST | `/v1/ventas/notas-credito` | Crea una nota de crédito. |
+| GET | `/v1/ventas/notas-credito/{id}` | Muestra una nota de crédito. |
+| POST | `/v1/ventas/notas-credito/{id}/aplicar` | Aplica una nota de crédito. |
+| POST | `/v1/ventas/notas-credito/{id}/anular` | Anula una nota de crédito. |
+
 ## Otros
 | Método | Ruta | Descripción |
 | ------ | ---- | ----------- |
 | GET | `/v1/estado-suscripcion` | Devuelve el estado de la suscripción actual. |
+| POST | `/v1/sri/secuencias/next` | Genera la siguiente secuencia para documentos SRI. |
 

--- a/apis.json
+++ b/apis.json
@@ -645,16 +645,17 @@
       "name": "estado-suscripcion",
       "item": [
         {
-          "name": "GET ",
+          "name": "GET estado-suscripcion",
           "request": {
             "method": "GET",
             "url": {
-              "raw": "{{base_url}}/api/estado-suscripcion",
+              "raw": "{{base_url}}/api/v1/estado-suscripcion",
               "host": [
                 "{{base_url}}"
               ],
               "path": [
                 "api",
+                "v1",
                 "estado-suscripcion"
               ]
             }
@@ -2118,6 +2119,457 @@
                 "usuarios",
                 "{id}",
                 "roles"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "cuentas",
+      "item": [
+        {
+          "name": "GET cuentas",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/v1/cuentas",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "cuentas"
+              ]
+            }
+          }
+        },
+        {
+          "name": "POST cuentas",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/v1/cuentas",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "cuentas"
+              ]
+            }
+          }
+        },
+        {
+          "name": "GET cuentas/{id}",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/v1/cuentas/{id}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "cuentas",
+                "{id}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "PUT cuentas/{id}",
+          "request": {
+            "method": "PUT",
+            "url": {
+              "raw": "{{base_url}}/api/v1/cuentas/{id}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "cuentas",
+                "{id}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "DELETE cuentas/{id}",
+          "request": {
+            "method": "DELETE",
+            "url": {
+              "raw": "{{base_url}}/api/v1/cuentas/{id}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "cuentas",
+                "{id}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "POST cuentas/{id}/items",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/v1/cuentas/{id}/items",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "cuentas",
+                "{id}",
+                "items"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "ventas-facturas",
+      "item": [
+        {
+          "name": "GET ventas/facturas",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/v1/ventas/facturas",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "ventas",
+                "facturas"
+              ]
+            }
+          }
+        },
+        {
+          "name": "POST ventas/facturas",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/v1/ventas/facturas",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "ventas",
+                "facturas"
+              ]
+            }
+          }
+        },
+        {
+          "name": "GET ventas/facturas/{id}",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/v1/ventas/facturas/{id}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "ventas",
+                "facturas",
+                "{id}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "PUT ventas/facturas/{id}",
+          "request": {
+            "method": "PUT",
+            "url": {
+              "raw": "{{base_url}}/api/v1/ventas/facturas/{id}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "ventas",
+                "facturas",
+                "{id}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "DELETE ventas/facturas/{id}",
+          "request": {
+            "method": "DELETE",
+            "url": {
+              "raw": "{{base_url}}/api/v1/ventas/facturas/{id}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "ventas",
+                "facturas",
+                "{id}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "POST ventas/facturas/{id}/aprobar",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/v1/ventas/facturas/{id}/aprobar",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "ventas",
+                "facturas",
+                "{id}",
+                "aprobar"
+              ]
+            }
+          }
+        },
+        {
+          "name": "POST ventas/facturas/{id}/anular",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/v1/ventas/facturas/{id}/anular",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "ventas",
+                "facturas",
+                "{id}",
+                "anular"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "cxc",
+      "item": [
+        {
+          "name": "GET cxc",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/v1/cxc",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "cxc"
+              ]
+            }
+          }
+        },
+        {
+          "name": "GET cxc/{id}",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/v1/cxc/{id}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "cxc",
+                "{id}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "POST cxc/pagos",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/v1/cxc/pagos",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "cxc",
+                "pagos"
+              ]
+            }
+          }
+        },
+        {
+          "name": "GET cxc/{id}/pagos",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/v1/cxc/{id}/pagos",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "cxc",
+                "{id}",
+                "pagos"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "ventas-notas-credito",
+      "item": [
+        {
+          "name": "GET ventas/notas-credito",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/v1/ventas/notas-credito",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "ventas",
+                "notas-credito"
+              ]
+            }
+          }
+        },
+        {
+          "name": "POST ventas/notas-credito",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/v1/ventas/notas-credito",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "ventas",
+                "notas-credito"
+              ]
+            }
+          }
+        },
+        {
+          "name": "GET ventas/notas-credito/{id}",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/v1/ventas/notas-credito/{id}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "ventas",
+                "notas-credito",
+                "{id}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "POST ventas/notas-credito/{id}/aplicar",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/v1/ventas/notas-credito/{id}/aplicar",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "ventas",
+                "notas-credito",
+                "{id}",
+                "aplicar"
+              ]
+            }
+          }
+        },
+        {
+          "name": "POST ventas/notas-credito/{id}/anular",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/v1/ventas/notas-credito/{id}/anular",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "ventas",
+                "notas-credito",
+                "{id}",
+                "anular"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "sri",
+      "item": [
+        {
+          "name": "POST sri/secuencias/next",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/v1/sri/secuencias/next",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "sri",
+                "secuencias",
+                "next"
               ]
             }
           }


### PR DESCRIPTION
## Resumen
- documentar cuentas, facturas, CxC y notas de crédito en README
- añadir nuevas secciones de endpoints en `apis.json`
- corregir ruta de estado de suscripción

## Testing
- ⚠️ `composer install` (falla: requiere credenciales de GitHub)


------
https://chatgpt.com/codex/tasks/task_e_68a34903e114832fad6bb8951bf2737c