### PR TITLE
Add RBAC routing and permissions management

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,32 +88,51 @@ Puedes importar el archivo `apis.json` en Postman para probar todos los endpoint
 | PUT | `/v1/suscripciones-locales/{id}` | Actualiza una relación suscripción-local. |
 
 ### Usuarios
-| Método | Ruta | Descripción |
-| ------ | ---- | ----------- |
-| GET | `/v1/usuarios` | Lista usuarios. |
-| POST | `/v1/usuarios` | Crea un usuario. |
-| GET | `/v1/usuarios/{id}` | Muestra los datos de un usuario. |
-| PUT | `/v1/usuarios/{id}` | Actualiza un usuario. |
-| DELETE | `/v1/usuarios/{id}` | Elimina un usuario. |
-| POST | `/v1/usuarios/{id}/roles` | Asigna roles a un usuario. |
+| Método | Ruta | Descripción | Permiso |
+| ------ | ---- | ----------- | ------- |
+| GET | `/v1/usuarios` | Lista usuarios. | `usuarios.ver` |
+| POST | `/v1/usuarios` | Crea un usuario. | `usuarios.crear` |
+| GET | `/v1/usuarios/{id}` | Muestra los datos de un usuario. | `usuarios.ver` |
+| PUT | `/v1/usuarios/{id}` | Actualiza un usuario. | `usuarios.editar` |
+| DELETE | `/v1/usuarios/{id}` | Elimina un usuario. | `usuarios.eliminar` |
+| POST | `/v1/usuarios/{id}/roles` | Asigna roles a un usuario. | `usuarios.asignar_roles` |
 
 ### Roles
-| Método | Ruta | Descripción |
-| ------ | ---- | ----------- |
-| GET | `/v1/roles` | Lista roles disponibles. |
-| POST | `/v1/roles` | Crea un rol. |
-| GET | `/v1/roles/{id}` | Muestra los datos de un rol. |
-| PUT | `/v1/roles/{id}` | Actualiza un rol. |
-| DELETE | `/v1/roles/{id}` | Elimina un rol. |
+| Método | Ruta | Descripción | Permiso |
+| ------ | ---- | ----------- | ------- |
+| GET | `/v1/roles` | Lista roles disponibles. | `roles.ver` |
+| POST | `/v1/roles` | Crea un rol. | `roles.crear` |
+| GET | `/v1/roles/{id}` | Muestra los datos de un rol. | `roles.ver` |
+| PUT | `/v1/roles/{id}` | Actualiza un rol. | `roles.editar` |
+| DELETE | `/v1/roles/{id}` | Elimina un rol. | `roles.eliminar` |
+| POST | `/v1/roles/{id}/permisos` | Asigna permisos a un rol. | `roles.asignar_permisos` |
 
 ### Permisos
-| Método | Ruta | Descripción |
-| ------ | ---- | ----------- |
-| GET | `/v1/permisos` | Lista permisos disponibles. |
-| POST | `/v1/permisos` | Crea un permiso. |
-| GET | `/v1/permisos/{id}` | Muestra los datos de un permiso. |
-| PUT | `/v1/permisos/{id}` | Actualiza un permiso. |
-| DELETE | `/v1/permisos/{id}` | Elimina un permiso. |
+| Método | Ruta | Descripción | Permiso |
+| ------ | ---- | ----------- | ------- |
+| GET | `/v1/permisos` | Lista permisos disponibles. | `permisos.ver` |
+| POST | `/v1/permisos` | Crea un permiso. | `permisos.crear` |
+| GET | `/v1/permisos/{id}` | Muestra los datos de un permiso. | `permisos.ver` |
+| PUT | `/v1/permisos/{id}` | Actualiza un permiso. | `permisos.editar` |
+| DELETE | `/v1/permisos/{id}` | Elimina un permiso. | `permisos.eliminar` |
+
+## Matriz RBAC
+| Permiso | admin | supervisor | cajero |
+| ------- | :---: | :--------: | :----: |
+| usuarios.ver | ✓ | ✓ | — |
+| usuarios.crear | ✓ | — | — |
+| usuarios.editar | ✓ | ✓ | — |
+| usuarios.eliminar | ✓ | — | — |
+| usuarios.asignar_roles | ✓ | — | — |
+| roles.ver | ✓ | ✓ | — |
+| roles.crear | ✓ | — | — |
+| roles.editar | ✓ | — | — |
+| roles.eliminar | ✓ | — | — |
+| roles.asignar_permisos | ✓ | — | — |
+| permisos.ver | ✓ | ✓ | — |
+| permisos.crear | ✓ | — | — |
+| permisos.editar | ✓ | — | — |
+| permisos.eliminar | ✓ | — | — |
 
 ### Unidades de medida
 | Método | Ruta | Descripción |

--- a/api_registry.json
+++ b/api_registry.json
@@ -1,0 +1,19 @@
+[
+  {"method":"GET","path":"/v1/usuarios","name":"Listar usuarios","module":"usuarios","permission":"usuarios.ver"},
+  {"method":"POST","path":"/v1/usuarios","name":"Crear usuario","module":"usuarios","permission":"usuarios.crear"},
+  {"method":"GET","path":"/v1/usuarios/{id}","name":"Ver usuario","module":"usuarios","permission":"usuarios.ver"},
+  {"method":"PUT","path":"/v1/usuarios/{id}","name":"Actualizar usuario","module":"usuarios","permission":"usuarios.editar"},
+  {"method":"DELETE","path":"/v1/usuarios/{id}","name":"Eliminar usuario","module":"usuarios","permission":"usuarios.eliminar"},
+  {"method":"POST","path":"/v1/usuarios/{id}/roles","name":"Asignar roles a usuario","module":"usuarios","permission":"usuarios.asignar_roles"},
+  {"method":"GET","path":"/v1/roles","name":"Listar roles","module":"roles","permission":"roles.ver"},
+  {"method":"POST","path":"/v1/roles","name":"Crear rol","module":"roles","permission":"roles.crear"},
+  {"method":"GET","path":"/v1/roles/{id}","name":"Ver rol","module":"roles","permission":"roles.ver"},
+  {"method":"PUT","path":"/v1/roles/{id}","name":"Actualizar rol","module":"roles","permission":"roles.editar"},
+  {"method":"DELETE","path":"/v1/roles/{id}","name":"Eliminar rol","module":"roles","permission":"roles.eliminar"},
+  {"method":"POST","path":"/v1/roles/{id}/permisos","name":"Asignar permisos a rol","module":"roles","permission":"roles.asignar_permisos"},
+  {"method":"GET","path":"/v1/permisos","name":"Listar permisos","module":"permisos","permission":"permisos.ver"},
+  {"method":"POST","path":"/v1/permisos","name":"Crear permiso","module":"permisos","permission":"permisos.crear"},
+  {"method":"GET","path":"/v1/permisos/{id}","name":"Ver permiso","module":"permisos","permission":"permisos.ver"},
+  {"method":"PUT","path":"/v1/permisos/{id}","name":"Actualizar permiso","module":"permisos","permission":"permisos.editar"},
+  {"method":"DELETE","path":"/v1/permisos/{id}","name":"Eliminar permiso","module":"permisos","permission":"permisos.eliminar"}
+]

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -27,6 +27,23 @@ class RolesAndPermissionsSeeder extends Seeder
 
         // Permisos mínimos (expande según tu UI)
         $permisos = [
+            // Usuarios
+            ['codigo' => 'usuarios.ver',                'nombre' => 'Ver usuarios'],
+            ['codigo' => 'usuarios.crear',              'nombre' => 'Crear usuarios'],
+            ['codigo' => 'usuarios.editar',             'nombre' => 'Editar usuarios'],
+            ['codigo' => 'usuarios.eliminar',           'nombre' => 'Eliminar usuarios'],
+            ['codigo' => 'usuarios.asignar_roles',      'nombre' => 'Asignar roles a usuarios'],
+            // Roles
+            ['codigo' => 'roles.ver',                   'nombre' => 'Ver roles'],
+            ['codigo' => 'roles.crear',                 'nombre' => 'Crear roles'],
+            ['codigo' => 'roles.editar',                'nombre' => 'Editar roles'],
+            ['codigo' => 'roles.eliminar',              'nombre' => 'Eliminar roles'],
+            ['codigo' => 'roles.asignar_permisos',      'nombre' => 'Asignar permisos a roles'],
+            // Permisos
+            ['codigo' => 'permisos.ver',                'nombre' => 'Ver permisos'],
+            ['codigo' => 'permisos.crear',              'nombre' => 'Crear permisos'],
+            ['codigo' => 'permisos.editar',             'nombre' => 'Editar permisos'],
+            ['codigo' => 'permisos.eliminar',           'nombre' => 'Eliminar permisos'],
             // Configuración
             ['codigo' => 'config.locales.gestionar',     'nombre' => 'Gestionar locales'],
             ['codigo' => 'config.usuarios.gestionar',    'nombre' => 'Gestionar usuarios'],
@@ -61,6 +78,7 @@ class RolesAndPermissionsSeeder extends Seeder
         $map = [
             'SUPER_ADMIN' => array_column($permisos, 'codigo'),
             'ADMIN_LOCAL' => [
+                'usuarios.ver','usuarios.editar','roles.ver','permisos.ver',
                 'config.usuarios.gestionar','productos.ver','productos.crear_editar','inventario.movimientos',
                 'proveedores.gestionar','pedidos.crear','cocina.ver','caja.cobrar','caja.cierres',
                 'ventas.facturacion','reportes.ver','reservas.gestionar','cotizaciones.gestionar'

--- a/routes/api.php
+++ b/routes/api.php
@@ -80,24 +80,25 @@ Route::prefix('v1')->middleware('auth.jwt')->group(function () {
         Route::get('/suscripciones-locales/{id}', [SuscripcionLocalController::class, 'show']);
         Route::put('/suscripciones-locales/{id}', [SuscripcionLocalController::class, 'update']);
 
-        Route::get('/usuarios', [UsuarioController::class, 'index']);
-        Route::post('/usuarios', [UsuarioController::class, 'store']);
-        Route::get('/usuarios/{id}', [UsuarioController::class, 'show']);
-        Route::put('/usuarios/{id}', [UsuarioController::class, 'update']);
-        Route::delete('/usuarios/{id}', [UsuarioController::class, 'destroy']);
-        Route::post('/usuarios/{id}/roles', [UsuarioController::class, 'assignRoles']);
+        Route::get('/usuarios', [UsuarioController::class, 'index'])->middleware('can:usuarios.ver');
+        Route::post('/usuarios', [UsuarioController::class, 'store'])->middleware('can:usuarios.crear');
+        Route::get('/usuarios/{id}', [UsuarioController::class, 'show'])->middleware('can:usuarios.ver');
+        Route::put('/usuarios/{id}', [UsuarioController::class, 'update'])->middleware('can:usuarios.editar');
+        Route::delete('/usuarios/{id}', [UsuarioController::class, 'destroy'])->middleware('can:usuarios.eliminar');
+        Route::post('/usuarios/{id}/roles', [UsuarioController::class, 'assignRoles'])->middleware('can:usuarios.asignar_roles');
 
-        Route::get('/roles', [RolController::class, 'index']);
-        Route::post('/roles', [RolController::class, 'store']);
-        Route::get('/roles/{id}', [RolController::class, 'show']);
-        Route::put('/roles/{id}', [RolController::class, 'update']);
-        Route::delete('/roles/{id}', [RolController::class, 'destroy']);
+        Route::get('/roles', [RolController::class, 'index'])->middleware('can:roles.ver');
+        Route::post('/roles', [RolController::class, 'store'])->middleware('can:roles.crear');
+        Route::get('/roles/{id}', [RolController::class, 'show'])->middleware('can:roles.ver');
+        Route::put('/roles/{id}', [RolController::class, 'update'])->middleware('can:roles.editar');
+        Route::delete('/roles/{id}', [RolController::class, 'destroy'])->middleware('can:roles.eliminar');
+        Route::post('/roles/{id}/permisos', [RolController::class, 'assignPermissions'])->middleware('can:roles.asignar_permisos');
 
-        Route::get('/permisos', [PermisoController::class, 'index']);
-        Route::post('/permisos', [PermisoController::class, 'store']);
-        Route::get('/permisos/{id}', [PermisoController::class, 'show']);
-        Route::put('/permisos/{id}', [PermisoController::class, 'update']);
-        Route::delete('/permisos/{id}', [PermisoController::class, 'destroy']);
+        Route::get('/permisos', [PermisoController::class, 'index'])->middleware('can:permisos.ver');
+        Route::post('/permisos', [PermisoController::class, 'store'])->middleware('can:permisos.crear');
+        Route::get('/permisos/{id}', [PermisoController::class, 'show'])->middleware('can:permisos.ver');
+        Route::put('/permisos/{id}', [PermisoController::class, 'update'])->middleware('can:permisos.editar');
+        Route::delete('/permisos/{id}', [PermisoController::class, 'destroy'])->middleware('can:permisos.eliminar');
 
         Route::get('/unidades', [UnidadMedidaController::class, 'index'])->middleware('can:productos.crear_editar');
         Route::post('/unidades', [UnidadMedidaController::class, 'store'])->middleware('can:productos.crear_editar');

--- a/tests/Feature/RolPermisosTest.php
+++ b/tests/Feature/RolPermisosTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class RolPermisosTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function login(string $email, string $password): string
+    {
+        $response = $this->postJson('/v1/auth/login', [
+            'email' => $email,
+            'password' => $password,
+        ]);
+        $response->assertStatus(200);
+        return $response->json('token');
+    }
+
+    public function test_requires_authentication(): void
+    {
+        $rolId = DB::table('roles')->where('codigo', 'CAJERO')->value('id');
+        $this->postJson("/v1/roles/{$rolId}/permisos", ['permisos' => []])
+            ->assertStatus(401);
+    }
+
+    public function test_forbidden_without_permission(): void
+    {
+        $rolId = DB::table('roles')->where('codigo', 'CAJERO')->value('id');
+        $token = $this->login('adminlocal@vendepro.io', 'VendePro#2025');
+        $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->postJson("/v1/roles/{$rolId}/permisos", ['permisos' => []])
+            ->assertStatus(403);
+    }
+
+    public function test_assign_permissions_success(): void
+    {
+        $rolId = DB::table('roles')->where('codigo', 'CAJERO')->value('id');
+        $token = $this->login('superadmin@vendepro.io', 'VendePro#2025');
+        $permCode = 'usuarios.ver';
+        $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->postJson("/v1/roles/{$rolId}/permisos", ['permisos' => [$permCode]])
+            ->assertStatus(200)
+            ->assertJsonPath('data.permisos.0', $permCode);
+        $permId = DB::table('permisos')->where('codigo', $permCode)->value('id');
+        $this->assertDatabaseHas('rol_permisos', ['rol_id' => $rolId, 'permiso_id' => $permId]);
+    }
+}
+


### PR DESCRIPTION
## Summary
- enforce permission middleware on user, role, and permission routes
- allow assigning permissions to roles
- document endpoints and permissions and register them in api_registry.json

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*
- `composer install` *(fails: GitHub token required / network timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68a352e8a1f0832fb1e93dd4947ad351