### PR TITLE
feat: add caja and payment modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,3 +270,66 @@ Puedes importar el archivo `apis.json` en Postman para probar todos los endpoint
 | GET | `/v1/estado-suscripcion` | Devuelve el estado de la suscripción actual. |
 | POST | `/v1/sri/secuencias/next` | Genera la siguiente secuencia para documentos SRI. |
 
+
+## Caja
+| Método | Ruta | Descripción | Permiso requerido |
+| ------ | ---- | ----------- | ----------------- |
+| POST | `/v1/caja/aperturas` | Abrir caja | `caja.aperturas.crear` |
+| GET | `/v1/caja/aperturas` | Listar aperturas | `caja.aperturas.ver` |
+| GET | `/v1/caja/aperturas/{id}` | Ver apertura | `caja.aperturas.ver` |
+| POST | `/v1/caja/movimientos` | Registrar movimiento | `caja.movimientos.crear` |
+| GET | `/v1/caja/movimientos` | Listar movimientos | `caja.aperturas.ver` |
+| POST | `/v1/caja/deposito` | Registrar depósito bancario | `caja.depositos.crear` |
+| POST | `/v1/caja/cierre` | Cerrar caja | `caja.cierre.crear` |
+| GET | `/v1/caja/estado` | Estado rápido de caja | `caja.aperturas.ver` |
+
+## Pagos de Venta
+| Método | Ruta | Descripción | Permiso requerido |
+| ------ | ---- | ----------- | ----------------- |
+| POST | `/v1/pagos-venta` | Registrar pago de venta | `pagos_venta.crear` |
+| GET | `/v1/pagos-venta` | Listar pagos de venta | `pagos_venta.ver` |
+| GET | `/v1/pagos-venta/{id}` | Ver pago de venta | `pagos_venta.ver` |
+| POST | `/v1/pagos-venta/{id}/anular` | Anular pago de venta | `pagos_venta.anular` |
+
+### Ejemplo Apertura de Caja
+```json
+POST /v1/caja/aperturas
+{
+  "local_id": 1,
+  "caja_id": 5,
+  "usuario_id": 41,
+  "saldo_inicial": 100.00
+}
+```
+Respuesta 201:
+```json
+{"data":{"id":1,"estado":"abierta"}}
+```
+
+### Ejemplo Pago Mixto
+```json
+POST /v1/pagos-venta
+{
+  "factura_id": 9876,
+  "items_pago": [{"metodo":"efectivo","monto":20.00}],
+  "caja": {"apertura_id": 10}
+}
+```
+
+### Códigos de error
+- 401 No autorizado
+- 403 Prohibido
+- 409 Conflicto
+- 422 Datos inválidos
+
+### Matriz RBAC
+| Permiso | admin | supervisor | cajero |
+| ------- | ----- | ---------- | ------ |
+| caja.aperturas.crear | ✓ | ✓ | ✓ |
+| caja.aperturas.ver | ✓ | ✓ | ✓ |
+| caja.movimientos.crear | ✓ | ✓ | ✓ |
+| caja.depositos.crear | ✓ | ✓ | ✓ |
+| caja.cierre.crear | ✓ | ✓ | ✓ |
+| pagos_venta.crear | ✓ | ✓ | ✓ |
+| pagos_venta.ver | ✓ | ✓ | ✓ |
+| pagos_venta.anular | ✓ | ✓ | ✓ |

--- a/api_registry.json
+++ b/api_registry.json
@@ -15,5 +15,17 @@
   {"method":"POST","path":"/v1/permisos","name":"Crear permiso","module":"permisos","permission":"permisos.crear"},
   {"method":"GET","path":"/v1/permisos/{id}","name":"Ver permiso","module":"permisos","permission":"permisos.ver"},
   {"method":"PUT","path":"/v1/permisos/{id}","name":"Actualizar permiso","module":"permisos","permission":"permisos.editar"},
-  {"method":"DELETE","path":"/v1/permisos/{id}","name":"Eliminar permiso","module":"permisos","permission":"permisos.eliminar"}
+  {"method":"DELETE","path":"/v1/permisos/{id}","name":"Eliminar permiso","module":"permisos","permission":"permisos.eliminar"},
+  {"method":"POST","path":"/v1/caja/aperturas","name":"Abrir caja","module":"caja","permission":"caja.aperturas.crear"},
+  {"method":"GET","path":"/v1/caja/aperturas","name":"Listar aperturas","module":"caja","permission":"caja.aperturas.ver"},
+  {"method":"GET","path":"/v1/caja/aperturas/{id}","name":"Ver apertura","module":"caja","permission":"caja.aperturas.ver"},
+  {"method":"POST","path":"/v1/caja/movimientos","name":"Registrar movimiento de caja","module":"caja","permission":"caja.movimientos.crear"},
+  {"method":"GET","path":"/v1/caja/movimientos","name":"Listar movimientos de caja","module":"caja","permission":"caja.aperturas.ver"},
+  {"method":"POST","path":"/v1/caja/deposito","name":"Registrar depósito","module":"caja","permission":"caja.depositos.crear"},
+  {"method":"POST","path":"/v1/caja/cierre","name":"Cerrar caja","module":"caja","permission":"caja.cierre.crear"},
+  {"method":"GET","path":"/v1/caja/estado","name":"Estado de caja","module":"caja","permission":"caja.aperturas.ver"},
+  {"method":"POST","path":"/v1/pagos-venta","name":"Registrar pago de venta","module":"pagos_venta","permission":"pagos_venta.crear"},
+  {"method":"GET","path":"/v1/pagos-venta","name":"Listar pagos de venta","module":"pagos_venta","permission":"pagos_venta.ver"},
+  {"method":"GET","path":"/v1/pagos-venta/{id}","name":"Ver pago de venta","module":"pagos_venta","permission":"pagos_venta.ver"},
+  {"method":"POST","path":"/v1/pagos-venta/{id}/anular","name":"Anular pago de venta","module":"pagos_venta","permission":"pagos_venta.anular"}
 ]

--- a/apis.json
+++ b/apis.json
@@ -2577,6 +2577,53 @@
       ]
     }
   ],
+  {
+    "name": "caja",
+    "item": [
+      {
+        "name": "POST caja/aperturas",
+        "request": {"method":"POST","url":{"raw":"{{base_url}}/api/v1/caja/aperturas","host":["{{base_url}}"],"path":["api","v1","caja","aperturas"]}}
+      },
+      {
+        "name": "POST caja/movimientos",
+        "request": {"method":"POST","url":{"raw":"{{base_url}}/api/v1/caja/movimientos","host":["{{base_url}}"],"path":["api","v1","caja","movimientos"]}}
+      },
+      {
+        "name": "POST caja/deposito",
+        "request": {"method":"POST","url":{"raw":"{{base_url}}/api/v1/caja/deposito","host":["{{base_url}}"],"path":["api","v1","caja","deposito"]}}
+      },
+      {
+        "name": "POST caja/cierre",
+        "request": {"method":"POST","url":{"raw":"{{base_url}}/api/v1/caja/cierre","host":["{{base_url}}"],"path":["api","v1","caja","cierre"]}}
+      },
+      {
+        "name": "GET caja/estado",
+        "request": {"method":"GET","url":{"raw":"{{base_url}}/api/v1/caja/estado","host":["{{base_url}}"],"path":["api","v1","caja","estado"]}}
+      }
+    ]
+  },
+  {
+    "name": "pagos-venta",
+    "item": [
+      {
+        "name": "POST pagos-venta",
+        "request": {"method":"POST","url":{"raw":"{{base_url}}/api/v1/pagos-venta","host":["{{base_url}}"],"path":["api","v1","pagos-venta"]}}
+      },
+      {
+        "name": "GET pagos-venta",
+        "request": {"method":"GET","url":{"raw":"{{base_url}}/api/v1/pagos-venta","host":["{{base_url}}"],"path":["api","v1","pagos-venta"]}}
+      },
+      {
+        "name": "GET pagos-venta/{id}",
+        "request": {"method":"GET","url":{"raw":"{{base_url}}/api/v1/pagos-venta/1","host":["{{base_url}}"],"path":["api","v1","pagos-venta","1"]}}
+      },
+      {
+        "name": "POST pagos-venta/{id}/anular",
+        "request": {"method":"POST","url":{"raw":"{{base_url}}/api/v1/pagos-venta/1/anular","host":["{{base_url}}"],"path":["api","v1","pagos-venta","1","anular"]}}
+      }
+    ]
+  }
+  ],
   "variable": [
     {
       "key": "base_url",

--- a/app/Http/Controllers/CajaAperturaController.php
+++ b/app/Http/Controllers/CajaAperturaController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\CajaApertura;
+use App\Http\Requests\StoreCajaAperturaRequest;
+use Illuminate\Http\Request;
+
+class CajaAperturaController extends Controller
+{
+    public function store(StoreCajaAperturaRequest $request)
+    {
+        $data = $request->validated();
+
+        $exists = CajaApertura::where('local_id', $data['local_id'])
+            ->where('caja_id', $data['caja_id'])
+            ->where('estado', 'abierta')
+            ->first();
+        if ($exists) {
+            return response()->json([
+                'error' => [
+                    'code' => 'CONFLICT',
+                    'message' => 'Ya existe apertura abierta'
+                ]
+            ], 409);
+        }
+
+        $apertura = CajaApertura::create($data);
+        return response()->json(['data' => $apertura], 201);
+    }
+
+    public function index(Request $request)
+    {
+        $query = CajaApertura::query();
+        if ($estado = $request->query('estado')) {
+            $query->where('estado', $estado);
+        }
+        if ($local = $request->query('local_id')) {
+            $query->where('local_id', $local);
+        }
+        if ($usuario = $request->query('usuario_id')) {
+            $query->where('usuario_id', $usuario);
+        }
+        if ($desde = $request->query('desde')) {
+            $query->whereDate('abierto_at', '>=', $desde);
+        }
+        if ($hasta = $request->query('hasta')) {
+            $query->whereDate('abierto_at', '<=', $hasta);
+        }
+        $per = min($request->query('per_page',20),100);
+        $page = max($request->query('page',1),1);
+        $aperturas = $query->paginate($per, ['*'], 'page', $page);
+        return [
+            'data' => $aperturas->items(),
+            'meta' => [
+                'page' => $aperturas->currentPage(),
+                'per_page' => $aperturas->perPage(),
+                'total' => $aperturas->total(),
+            ]
+        ];
+    }
+
+    public function show($id)
+    {
+        $apertura = CajaApertura::find($id);
+        if (!$apertura) {
+            return response()->json(['error' => ['code' => 'NOT_FOUND','message' => 'No encontrado']],404);
+        }
+        // Placeholder totals
+        $apertura->totales_por_medio = [
+            'efectivo' => 0,
+            'tarjeta' => 0,
+            'transferencia' => 0,
+            'otros' => 0
+        ];
+        return ['data' => $apertura];
+    }
+}

--- a/app/Http/Controllers/CajaCierreController.php
+++ b/app/Http/Controllers/CajaCierreController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\CajaApertura;
+use App\Models\CajaMovimiento;
+use App\Models\CajaCierre;
+use App\Http\Requests\StoreCajaCierreRequest;
+use Illuminate\Support\Facades\DB;
+
+class CajaCierreController extends Controller
+{
+    public function store(StoreCajaCierreRequest $request)
+    {
+        $data = $request->validated();
+        $apertura = CajaApertura::find($data['apertura_id']);
+        if (!$apertura || $apertura->estado !== 'abierta') {
+            return response()->json([
+                'error' => ['code' => 'CONFLICT','message' => 'Apertura no disponible']
+            ],409);
+        }
+        $ingresos = CajaMovimiento::where('apertura_id',$apertura->id)
+            ->whereIn('tipo',['ingreso','venta','propina'])
+            ->sum('monto');
+        $egresos = CajaMovimiento::where('apertura_id',$apertura->id)
+            ->whereIn('tipo',['egreso','cambio','deposito'])
+            ->sum('monto');
+        $esperado = $apertura->saldo_inicial + $ingresos - $egresos;
+        $contado = $data['efectivo_total_contado'];
+        $cierre = CajaCierre::create([
+            'apertura_id' => $apertura->id,
+            'esperado_efectivo' => $esperado,
+            'contado_efectivo' => $contado,
+            'diferencia' => round($contado - $esperado,2),
+            'detalle_conteo' => $data['conteo_efectivo'] ?? [],
+            'observacion' => $data['observacion'] ?? null,
+        ]);
+        $apertura->estado = 'cerrada';
+        $apertura->cerrado_at = now();
+        $apertura->save();
+        return ['data' => $cierre];
+    }
+}

--- a/app/Http/Controllers/CajaDepositoController.php
+++ b/app/Http/Controllers/CajaDepositoController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\CajaMovimiento;
+use App\Models\CajaApertura;
+use App\Http\Requests\StoreCajaDepositoRequest;
+
+class CajaDepositoController extends Controller
+{
+    public function store(StoreCajaDepositoRequest $request)
+    {
+        $data = $request->validated();
+        $apertura = CajaApertura::find($data['apertura_id']);
+        if (!$apertura || $apertura->estado !== 'abierta') {
+            return response()->json([
+                'error' => ['code' => 'CONFLICT','message' => 'Apertura no disponible']
+            ],409);
+        }
+        $data['tipo'] = 'deposito';
+        $mov = CajaMovimiento::create($data);
+        return response()->json(['data' => $mov],201);
+    }
+}

--- a/app/Http/Controllers/CajaEstadoController.php
+++ b/app/Http/Controllers/CajaEstadoController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\CajaApertura;
+use Illuminate\Http\Request;
+
+class CajaEstadoController extends Controller
+{
+    public function index(Request $request)
+    {
+        $local = $request->query('local_id');
+        $caja = $request->query('caja_id');
+        $apertura = CajaApertura::where('local_id',$local)
+            ->where('caja_id',$caja)
+            ->where('estado','abierta')
+            ->first();
+        if ($apertura) {
+            return [
+                'abierta' => true,
+                'apertura_id' => $apertura->id,
+                'usuario_id' => $apertura->usuario_id,
+                'saldo_efectivo' => $apertura->saldo_inicial,
+            ];
+        }
+        return ['abierta' => false];
+    }
+}

--- a/app/Http/Controllers/CajaMovimientoController.php
+++ b/app/Http/Controllers/CajaMovimientoController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\CajaMovimiento;
+use App\Models\CajaApertura;
+use App\Http\Requests\StoreCajaMovimientoRequest;
+use Illuminate\Http\Request;
+
+class CajaMovimientoController extends Controller
+{
+    public function store(StoreCajaMovimientoRequest $request)
+    {
+        $data = $request->validated();
+        $apertura = CajaApertura::find($data['apertura_id']);
+        if (!$apertura || $apertura->estado !== 'abierta') {
+            return response()->json([
+                'error' => ['code' => 'CONFLICT','message' => 'Apertura no disponible']
+            ],409);
+        }
+        $mov = CajaMovimiento::create($data);
+        return response()->json(['data' => $mov],201);
+    }
+
+    public function index(Request $request)
+    {
+        $query = CajaMovimiento::query();
+        if ($apertura = $request->query('apertura_id')) {
+            $query->where('apertura_id', $apertura);
+        }
+        if ($tipo = $request->query('tipo')) {
+            $query->where('tipo', $tipo);
+        }
+        if ($desde = $request->query('desde')) {
+            $query->whereDate('created_at','>=',$desde);
+        }
+        if ($hasta = $request->query('hasta')) {
+            $query->whereDate('created_at','<=',$hasta);
+        }
+        $per = min($request->query('per_page',20),100);
+        $page = max($request->query('page',1),1);
+        $movs = $query->paginate($per,['*'],'page',$page);
+        return [
+            'data' => $movs->items(),
+            'meta' => [
+                'page' => $movs->currentPage(),
+                'per_page' => $movs->perPage(),
+                'total' => $movs->total(),
+            ]
+        ];
+    }
+}

--- a/app/Http/Controllers/PagoVentaController.php
+++ b/app/Http/Controllers/PagoVentaController.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\PagoVenta;
+use App\Models\PagoVentaDetalle;
+use App\Models\CajaApertura;
+use App\Models\CajaMovimiento;
+use App\Http\Requests\StorePagoVentaRequest;
+use App\Http\Requests\AnularPagoVentaRequest;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class PagoVentaController extends Controller
+{
+    public function store(StorePagoVentaRequest $request)
+    {
+        $data = $request->validated();
+        $idempotency = $data['idempotency_key'] ?? $request->header('Idempotency-Key');
+        if ($idempotency) {
+            $existing = PagoVenta::where('factura_id',$data['factura_id'])
+                ->where('idempotency_key',$idempotency)
+                ->first();
+            if ($existing) {
+                return ['data' => $existing];
+            }
+        }
+
+        $items = $data['items_pago'];
+        $total = collect($items)->sum('monto') + ($data['propina'] ?? 0) + ($data['redondeo'] ?? 0);
+
+        // efectivo requires apertura
+        $requiresCaja = collect($items)->contains(fn($i) => $i['metodo'] === 'efectivo');
+        if ($requiresCaja) {
+            $aperturaId = $data['caja']['apertura_id'] ?? null;
+            $apertura = CajaApertura::find($aperturaId);
+            if (!$apertura || $apertura->estado !== 'abierta') {
+                return response()->json([
+                    'error' => ['code' => 'CONFLICT','message' => 'Caja no abierta']
+                ],409);
+            }
+        }
+
+        return DB::transaction(function() use ($data,$items,$total,$idempotency,$requiresCaja) {
+            $pago = PagoVenta::create([
+                'factura_id' => $data['factura_id'],
+                'total' => $total,
+                'propina' => $data['propina'] ?? 0,
+                'redondeo' => $data['redondeo'] ?? 0,
+                'apertura_id' => $data['caja']['apertura_id'] ?? null,
+                'idempotency_key' => $idempotency,
+            ]);
+            foreach ($items as $i) {
+                PagoVentaDetalle::create([
+                    'pago_id' => $pago->id,
+                    'metodo' => $i['metodo'],
+                    'monto' => $i['monto'],
+                    'detalle' => $i['tarjeta'] ?? $i['transferencia'] ?? null,
+                ]);
+                if ($i['metodo'] === 'efectivo' && $requiresCaja) {
+                    CajaMovimiento::create([
+                        'apertura_id' => $data['caja']['apertura_id'],
+                        'tipo' => 'venta',
+                        'monto' => $i['monto'],
+                        'motivo' => 'Pago factura',
+                    ]);
+                }
+            }
+            if (($data['propina'] ?? 0) > 0 && $requiresCaja) {
+                CajaMovimiento::create([
+                    'apertura_id' => $data['caja']['apertura_id'],
+                    'tipo' => 'propina',
+                    'monto' => $data['propina'],
+                    'motivo' => 'Propina',
+                ]);
+            }
+            return response()->json(['data' => $pago],201);
+        });
+    }
+
+    public function index(Request $request)
+    {
+        $query = PagoVenta::query();
+        if ($factura = $request->query('factura_id')) {
+            $query->where('factura_id',$factura);
+        }
+        if ($metodo = $request->query('metodo')) {
+            $query->whereHas('detalles', fn($q) => $q->where('metodo',$metodo));
+        }
+        if ($desde = $request->query('desde')) {
+            $query->whereDate('created_at','>=',$desde);
+        }
+        if ($hasta = $request->query('hasta')) {
+            $query->whereDate('created_at','<=',$hasta);
+        }
+        $per = min($request->query('per_page',20),100);
+        $page = max($request->query('page',1),1);
+        $rows = $query->paginate($per,['*'],'page',$page);
+        return [
+            'data' => $rows->items(),
+            'meta' => [
+                'page' => $rows->currentPage(),
+                'per_page' => $rows->perPage(),
+                'total' => $rows->total(),
+            ]
+        ];
+    }
+
+    public function show($id)
+    {
+        $pago = PagoVenta::with('detalles')->find($id);
+        if (!$pago) {
+            return response()->json(['error' => ['code'=>'NOT_FOUND','message'=>'No encontrado']],404);
+        }
+        return ['data' => $pago];
+    }
+
+    public function anular($id, AnularPagoVentaRequest $request)
+    {
+        $pago = PagoVenta::with('detalles')->find($id);
+        if (!$pago || $pago->estado !== 'vigente') {
+            return response()->json(['error' => ['code'=>'CONFLICT','message'=>'No se puede anular']],409);
+        }
+        $pago->estado = 'anulado';
+        $pago->save();
+        foreach ($pago->detalles as $d) {
+            if ($d->metodo === 'efectivo' && $pago->apertura_id) {
+                CajaMovimiento::create([
+                    'apertura_id' => $pago->apertura_id,
+                    'tipo' => 'ajuste',
+                    'monto' => -1 * $d->monto,
+                    'motivo' => 'Anulación pago',
+                ]);
+            }
+        }
+        return ['data' => $pago];
+    }
+}

--- a/app/Http/Requests/AnularPagoVentaRequest.php
+++ b/app/Http/Requests/AnularPagoVentaRequest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Requests;
+
+class AnularPagoVentaRequest extends ApiFormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'motivo' => ['required','string'],
+        ];
+    }
+}

--- a/app/Http/Requests/StoreCajaAperturaRequest.php
+++ b/app/Http/Requests/StoreCajaAperturaRequest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Requests;
+
+class StoreCajaAperturaRequest extends ApiFormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'local_id' => ['required','integer'],
+            'caja_id' => ['required','integer'],
+            'usuario_id' => ['required','integer'],
+            'saldo_inicial' => ['required','numeric'],
+            'observacion' => ['nullable','string'],
+        ];
+    }
+}

--- a/app/Http/Requests/StoreCajaCierreRequest.php
+++ b/app/Http/Requests/StoreCajaCierreRequest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Requests;
+
+class StoreCajaCierreRequest extends ApiFormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'apertura_id' => ['required','integer'],
+            'conteo_efectivo' => ['nullable','array'],
+            'conteo_efectivo.*' => ['integer'],
+            'efectivo_total_contado' => ['required','numeric'],
+            'observacion' => ['nullable','string'],
+        ];
+    }
+}

--- a/app/Http/Requests/StoreCajaDepositoRequest.php
+++ b/app/Http/Requests/StoreCajaDepositoRequest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Requests;
+
+class StoreCajaDepositoRequest extends ApiFormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'apertura_id' => ['required','integer'],
+            'monto' => ['required','numeric'],
+            'banco' => ['required','string'],
+            'referencia' => ['required','string'],
+            'fecha_deposito' => ['required','date'],
+        ];
+    }
+}

--- a/app/Http/Requests/StoreCajaMovimientoRequest.php
+++ b/app/Http/Requests/StoreCajaMovimientoRequest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Requests;
+
+class StoreCajaMovimientoRequest extends ApiFormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'apertura_id' => ['required','integer'],
+            'tipo' => ['required','in:ingreso,egreso,ajuste,deposito,venta,propina,cambio'],
+            'monto' => ['required','numeric'],
+            'motivo' => ['required','string'],
+            'referencia' => ['nullable','string'],
+            'banco' => ['nullable','string'],
+            'fecha_deposito' => ['nullable','date'],
+        ];
+    }
+}

--- a/app/Http/Requests/StorePagoVentaRequest.php
+++ b/app/Http/Requests/StorePagoVentaRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests;
+
+class StorePagoVentaRequest extends ApiFormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'factura_id' => ['required','integer'],
+            'cliente_id' => ['nullable','integer'],
+            'items_pago' => ['required','array','min:1'],
+            'items_pago.*.metodo' => ['required','string'],
+            'items_pago.*.monto' => ['required','numeric'],
+            'items_pago.*.tarjeta' => ['nullable','array'],
+            'items_pago.*.transferencia' => ['nullable','array'],
+            'propina' => ['nullable','numeric'],
+            'redondeo' => ['nullable','numeric'],
+            'caja.apertura_id' => ['nullable','integer'],
+            'observacion' => ['nullable','string'],
+            'idempotency_key' => ['nullable','string'],
+        ];
+    }
+}

--- a/app/Models/CajaApertura.php
+++ b/app/Models/CajaApertura.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class CajaApertura extends Model
+{
+    use SoftDeletes;
+
+    protected $table = 'caja_aperturas';
+
+    protected $fillable = [
+        'local_id','caja_id','usuario_id','saldo_inicial','abierto_at','cerrado_at','estado','observacion'
+    ];
+
+    protected $casts = [
+        'abierto_at' => 'datetime',
+        'cerrado_at' => 'datetime',
+    ];
+}

--- a/app/Models/CajaCierre.php
+++ b/app/Models/CajaCierre.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class CajaCierre extends Model
+{
+    protected $table = 'caja_cierres';
+
+    protected $fillable = [
+        'apertura_id','esperado_efectivo','contado_efectivo','diferencia','detalle_conteo','observacion'
+    ];
+
+    protected $casts = [
+        'detalle_conteo' => 'array',
+    ];
+}

--- a/app/Models/CajaMovimiento.php
+++ b/app/Models/CajaMovimiento.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class CajaMovimiento extends Model
+{
+    protected $table = 'caja_movimientos';
+
+    protected $fillable = [
+        'apertura_id','tipo','monto','motivo','referencia','banco','fecha_deposito'
+    ];
+
+    protected $casts = [
+        'fecha_deposito' => 'date',
+    ];
+}

--- a/app/Models/CatalogoMetodoPago.php
+++ b/app/Models/CatalogoMetodoPago.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class CatalogoMetodoPago extends Model
+{
+    protected $table = 'catalogo_metodos_pago';
+
+    protected $fillable = ['codigo','nombre','activo'];
+}

--- a/app/Models/PagoVenta.php
+++ b/app/Models/PagoVenta.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class PagoVenta extends Model
+{
+    protected $table = 'pagos_venta';
+
+    protected $fillable = [
+        'factura_id','total','propina','redondeo','apertura_id','estado','idempotency_key'
+    ];
+
+    public function detalles()
+    {
+        return $this->hasMany(PagoVentaDetalle::class, 'pago_id');
+    }
+}

--- a/app/Models/PagoVentaDetalle.php
+++ b/app/Models/PagoVentaDetalle.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class PagoVentaDetalle extends Model
+{
+    protected $table = 'pagos_venta_detalle';
+
+    protected $fillable = ['pago_id','metodo','monto','detalle'];
+
+    protected $casts = [
+        'detalle' => 'array',
+    ];
+}

--- a/database/migrations/2025_08_18_100000_create_caja_and_pagos_venta_tables.php
+++ b/database/migrations/2025_08_18_100000_create_caja_and_pagos_venta_tables.php
@@ -1,0 +1,86 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('caja_aperturas', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('local_id');
+            $table->unsignedBigInteger('caja_id');
+            $table->unsignedBigInteger('usuario_id');
+            $table->decimal('saldo_inicial', 12, 2)->default(0);
+            $table->timestamp('abierto_at')->useCurrent();
+            $table->timestamp('cerrado_at')->nullable();
+            $table->string('estado', 20)->default('abierta');
+            $table->string('observacion')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        Schema::create('caja_movimientos', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('apertura_id');
+            $table->string('tipo', 20);
+            $table->decimal('monto', 12, 2);
+            $table->string('motivo');
+            $table->string('referencia')->nullable();
+            $table->string('banco')->nullable();
+            $table->date('fecha_deposito')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('caja_cierres', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('apertura_id');
+            $table->decimal('esperado_efectivo', 12, 2);
+            $table->decimal('contado_efectivo', 12, 2);
+            $table->decimal('diferencia', 12, 2);
+            $table->json('detalle_conteo')->nullable();
+            $table->string('observacion')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('catalogo_metodos_pago', function (Blueprint $table) {
+            $table->id();
+            $table->string('codigo')->unique();
+            $table->string('nombre');
+            $table->boolean('activo')->default(true);
+            $table->timestamps();
+        });
+
+        Schema::create('pagos_venta', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('factura_id');
+            $table->decimal('total', 12, 2);
+            $table->decimal('propina', 12, 2)->default(0);
+            $table->decimal('redondeo', 12, 2)->default(0);
+            $table->unsignedBigInteger('apertura_id')->nullable();
+            $table->string('estado', 20)->default('vigente');
+            $table->string('idempotency_key')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('pagos_venta_detalle', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('pago_id');
+            $table->string('metodo');
+            $table->decimal('monto', 12, 2);
+            $table->json('detalle')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('pagos_venta_detalle');
+        Schema::dropIfExists('pagos_venta');
+        Schema::dropIfExists('catalogo_metodos_pago');
+        Schema::dropIfExists('caja_cierres');
+        Schema::dropIfExists('caja_movimientos');
+        Schema::dropIfExists('caja_aperturas');
+    }
+};

--- a/database/seeders/CatalogosBasicosSeeder.php
+++ b/database/seeders/CatalogosBasicosSeeder.php
@@ -52,6 +52,23 @@ class CatalogosBasicosSeeder extends Seeder
             );
         }
 
+        // Catálogo de métodos de pago
+        $catalogo = [
+            ['codigo' => 'efectivo', 'nombre' => 'Efectivo'],
+            ['codigo' => 'tarjeta', 'nombre' => 'Tarjeta'],
+            ['codigo' => 'transferencia', 'nombre' => 'Transferencia'],
+            ['codigo' => 'cheque', 'nombre' => 'Cheque'],
+            ['codigo' => 'vale', 'nombre' => 'Vale'],
+            ['codigo' => 'giftcard', 'nombre' => 'Giftcard'],
+            ['codigo' => 'otros', 'nombre' => 'Otros'],
+        ];
+        foreach ($catalogo as $c) {
+            DB::table('catalogo_metodos_pago')->updateOrInsert(
+                ['codigo' => $c['codigo']],
+                ['nombre' => $c['nombre'], 'activo' => 1]
+            );
+        }
+
         // Categorías
         $categorias = [
             ['empresa_id' => $empresaId, 'nombre' => 'General', 'padre_id' => null, 'orden' => 1],

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -65,6 +65,15 @@ class RolesAndPermissionsSeeder extends Seeder
             // Reservas / Cotizaciones
             ['codigo' => 'reservas.gestionar',           'nombre' => 'Gestionar reservas'],
             ['codigo' => 'cotizaciones.gestionar',       'nombre' => 'Gestionar cotizaciones'],
+            // Caja avanzadas
+            ['codigo' => 'caja.aperturas.crear',         'nombre' => 'Abrir caja'],
+            ['codigo' => 'caja.aperturas.ver',           'nombre' => 'Ver aperturas'],
+            ['codigo' => 'caja.movimientos.crear',       'nombre' => 'Crear movimientos de caja'],
+            ['codigo' => 'caja.depositos.crear',         'nombre' => 'Crear depósitos de caja'],
+            ['codigo' => 'caja.cierre.crear',            'nombre' => 'Cerrar caja'],
+            ['codigo' => 'pagos_venta.crear',            'nombre' => 'Registrar pagos de venta'],
+            ['codigo' => 'pagos_venta.ver',              'nombre' => 'Ver pagos de venta'],
+            ['codigo' => 'pagos_venta.anular',           'nombre' => 'Anular pagos de venta'],
         ];
 
         foreach ($permisos as $p) {
@@ -81,10 +90,15 @@ class RolesAndPermissionsSeeder extends Seeder
                 'usuarios.ver','usuarios.editar','roles.ver','permisos.ver',
                 'config.usuarios.gestionar','productos.ver','productos.crear_editar','inventario.movimientos',
                 'proveedores.gestionar','pedidos.crear','cocina.ver','caja.cobrar','caja.cierres',
-                'ventas.facturacion','reportes.ver','reservas.gestionar','cotizaciones.gestionar'
+                'ventas.facturacion','reportes.ver','reservas.gestionar','cotizaciones.gestionar',
+                'caja.aperturas.crear','caja.aperturas.ver','caja.movimientos.crear','caja.depositos.crear',
+                'caja.cierre.crear','pagos_venta.crear','pagos_venta.ver','pagos_venta.anular'
             ],
             'MESERO'      => ['pedidos.crear','productos.ver','reservas.gestionar'],
-            'CAJERO'      => ['caja.cobrar','caja.cierres','ventas.facturacion','reportes.ver'],
+            'CAJERO'      => ['caja.cobrar','caja.cierres','ventas.facturacion','reportes.ver',
+                'caja.aperturas.crear','caja.aperturas.ver','caja.movimientos.crear','caja.depositos.crear',
+                'caja.cierre.crear','pagos_venta.crear','pagos_venta.ver','pagos_venta.anular'
+            ],
             'COCINA'      => ['cocina.ver'],
         ];
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -31,6 +31,12 @@ use App\Http\Controllers\FacturaController;
 use App\Http\Controllers\CxcVentaController;
 use App\Http\Controllers\NotaCreditoController;
 use App\Http\Controllers\Sri\SecuenciaController;
+use App\Http\Controllers\CajaAperturaController;
+use App\Http\Controllers\CajaMovimientoController;
+use App\Http\Controllers\CajaDepositoController;
+use App\Http\Controllers\CajaCierreController;
+use App\Http\Controllers\CajaEstadoController;
+use App\Http\Controllers\PagoVentaController;
 
 Route::prefix('v1/auth')->group(function () {
     Route::post('/login', [AuthController::class, 'login']);
@@ -186,6 +192,22 @@ Route::prefix('v1')->middleware('auth.jwt')->group(function () {
         Route::get('/ventas/notas-credito/{id}', [NotaCreditoController::class,'show']);
         Route::post('/ventas/notas-credito/{id}/aplicar', [NotaCreditoController::class,'aplicar']);
         Route::post('/ventas/notas-credito/{id}/anular', [NotaCreditoController::class,'anular']);
+
+        // Caja
+        Route::post('/caja/aperturas', [CajaAperturaController::class,'store'])->middleware('can:caja.aperturas.crear');
+        Route::get('/caja/aperturas', [CajaAperturaController::class,'index'])->middleware('can:caja.aperturas.ver');
+        Route::get('/caja/aperturas/{id}', [CajaAperturaController::class,'show'])->middleware('can:caja.aperturas.ver');
+        Route::post('/caja/movimientos', [CajaMovimientoController::class,'store'])->middleware('can:caja.movimientos.crear');
+        Route::get('/caja/movimientos', [CajaMovimientoController::class,'index'])->middleware('can:caja.aperturas.ver');
+        Route::post('/caja/deposito', [CajaDepositoController::class,'store'])->middleware('can:caja.depositos.crear');
+        Route::post('/caja/cierre', [CajaCierreController::class,'store'])->middleware('can:caja.cierre.crear');
+        Route::get('/caja/estado', [CajaEstadoController::class,'index'])->middleware('can:caja.aperturas.ver');
+
+        // Pagos de venta
+        Route::post('/pagos-venta', [PagoVentaController::class,'store'])->middleware(['can:pagos_venta.crear','idempotency']);
+        Route::get('/pagos-venta', [PagoVentaController::class,'index'])->middleware('can:pagos_venta.ver');
+        Route::get('/pagos-venta/{id}', [PagoVentaController::class,'show'])->middleware('can:pagos_venta.ver');
+        Route::post('/pagos-venta/{id}/anular', [PagoVentaController::class,'anular'])->middleware('can:pagos_venta.anular');
     });
 
     Route::post('/sri/secuencias/next',[SecuenciaController::class,'next']);

--- a/tests/Feature/CajaPagosVentaTest.php
+++ b/tests/Feature/CajaPagosVentaTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Models\User;
+use App\Models\CajaApertura;
+use App\Models\PagoVenta;
+
+class CajaPagosVentaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_protected_routes_require_auth()
+    {
+        $this->postJson('/api/v1/caja/aperturas', [])->assertStatus(401);
+    }
+
+    public function test_apertura_duplicate_conflict()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user, 'api');
+        CajaApertura::create([
+            'local_id'=>1,'caja_id'=>1,'usuario_id'=>$user->id,'saldo_inicial'=>0
+        ]);
+        $this->postJson('/api/v1/caja/aperturas',[
+            'local_id'=>1,'caja_id'=>1,'usuario_id'=>$user->id,'saldo_inicial'=>0
+        ])->assertStatus(409);
+    }
+
+    public function test_pago_cash_without_apertura_conflict()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user, 'api');
+        $this->postJson('/api/v1/pagos-venta',[
+            'factura_id'=>1,
+            'items_pago'=>[['metodo'=>'efectivo','monto'=>10]],
+            'caja'=>['apertura_id'=>999]
+        ])->assertStatus(409);
+    }
+}


### PR DESCRIPTION
## Summary
- add migrations, models and controllers for caja and pagos de venta
- seed permissions and payment methods
- document new endpoints and update api registry

## Testing
- `phpunit` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a3587240ac832f8150f642601f8df8