### PR TITLE
feat: add inventory API skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Puedes importar el archivo `apis.json` en Postman para probar todos los endpoint
 | DELETE | `/v1/permisos/{id}` | Elimina un permiso. | `permisos.eliminar` |
 
 ## Matriz RBAC
-| Permiso | admin | supervisor | cajero |
+| Permiso | admin | supervisor | bodega |
 | ------- | :---: | :--------: | :----: |
 | usuarios.ver | ✓ | ✓ | — |
 | usuarios.crear | ✓ | — | — |
@@ -151,6 +151,23 @@ Puedes importar el archivo `apis.json` en Postman para probar todos los endpoint
 | sri.establecimientos.eliminar | ✓ | — | — |
 | sri.estados.ver | ✓ | ✓ | ✓ |
 | sri.callback.recibir | ✓ | — | — |
+| inventario.stock.ver | ✓ | ✓ | ✓ |
+| inventario.movimientos.ver | ✓ | ✓ | ✓ |
+| inventario.ajustes.crear | ✓ | ✓ | ✓ |
+| inventario.transferencias.crear | ✓ | ✓ | ✓ |
+| inventario.transferencias.ver | ✓ | ✓ | ✓ |
+| inventario.transferencias.recibir | ✓ | ✓ | ✓ |
+| inventario.transferencias.cancelar | ✓ | ✓ | ✓ |
+| inventario.conteos.crear | ✓ | ✓ | ✓ |
+| inventario.conteos.capturas | ✓ | ✓ | ✓ |
+| inventario.conteos.cerrar | ✓ | ✓ | ✓ |
+| inventario.conteos.ver | ✓ | ✓ | ✓ |
+| inventario.lotes.ver | ✓ | ✓ | ✓ |
+| inventario.alertas.ver | ✓ | ✓ | ✓ |
+| inventario.produccion.crear | ✓ | ✓ | ✓ |
+| inventario.mermas.crear | ✓ | ✓ | ✓ |
+| inventario.costos.ver | ✓ | ✓ | ✓ |
+| inventario.costos.recalcular | ✓ | ✓ | ✓ |
 
 ### Unidades de medida
 | Método | Ruta | Descripción |
@@ -350,6 +367,61 @@ POST /v1/pagos-venta
 | POST | `/v1/facturas/{id}/email` | Envía por email | 200 | `facturas.enviar_email` |
 | POST | `/v1/facturas/{id}/anular` | Anula factura | 200 | `facturas.anular` |
 
+## Inventario
+
+### Stock
+| Método | Ruta | Descripción | Permiso |
+| ------ | ---- | ----------- | ------- |
+| GET | `/v1/stock` | Consultar stock por bodega y producto. | `inventario.stock.ver` |
+| GET | `/v1/stock/kardex` | Ver kardex del producto. | `inventario.stock.ver` |
+
+### Movimientos
+| Método | Ruta | Descripción | Permiso |
+| ------ | ---- | ----------- | ------- |
+| GET | `/v1/inventario/movimientos` | Listar movimientos de inventario. | `inventario.movimientos.ver` |
+| GET | `/v1/inventario/movimientos/{id}` | Detalle de un movimiento. | `inventario.movimientos.ver` |
+
+### Ajustes
+| Método | Ruta | Descripción | Permiso |
+| ------ | ---- | ----------- | ------- |
+| POST | `/v1/inventario/ajustes` | Crear ajuste de inventario. | `inventario.ajustes.crear` |
+
+### Transferencias
+| Método | Ruta | Descripción | Permiso |
+| ------ | ---- | ----------- | ------- |
+| POST | `/v1/inventario/transferencias` | Crear transferencia entre bodegas. | `inventario.transferencias.crear` |
+| GET | `/v1/inventario/transferencias` | Listar transferencias. | `inventario.transferencias.ver` |
+| GET | `/v1/inventario/transferencias/{id}` | Detalle de transferencia. | `inventario.transferencias.ver` |
+| POST | `/v1/inventario/transferencias/{id}/recibir` | Recibir transferencia. | `inventario.transferencias.recibir` |
+| POST | `/v1/inventario/transferencias/{id}/cancelar` | Cancelar transferencia. | `inventario.transferencias.cancelar` |
+
+### Conteos
+| Método | Ruta | Descripción | Permiso |
+| ------ | ---- | ----------- | ------- |
+| POST | `/v1/inventario/conteos` | Crear conteo de inventario. | `inventario.conteos.crear` |
+| POST | `/v1/inventario/conteos/{id}/capturas` | Registrar capturas de conteo. | `inventario.conteos.capturas` |
+| POST | `/v1/inventario/conteos/{id}/cerrar` | Cerrar conteo. | `inventario.conteos.cerrar` |
+| GET | `/v1/inventario/conteos` | Listar conteos. | `inventario.conteos.ver` |
+| GET | `/v1/inventario/conteos/{id}` | Ver conteo. | `inventario.conteos.ver` |
+
+### Lotes
+| Método | Ruta | Descripción | Permiso |
+| ------ | ---- | ----------- | ------- |
+| GET | `/v1/inventario/lotes` | Listar lotes y caducidades. | `inventario.lotes.ver` |
+| GET | `/v1/inventario/alertas` | Alertas de inventario. | `inventario.alertas.ver` |
+
+### Producción y Mermas
+| Método | Ruta | Descripción | Permiso |
+| ------ | ---- | ----------- | ------- |
+| POST | `/v1/inventario/produccion` | Registrar producción. | `inventario.produccion.crear` |
+| POST | `/v1/inventario/mermas` | Registrar merma. | `inventario.mermas.crear` |
+
+### Costos
+| Método | Ruta | Descripción | Permiso |
+| ------ | ---- | ----------- | ------- |
+| GET | `/v1/inventario/costos` | Consultar costos de inventario. | `inventario.costos.ver` |
+| POST | `/v1/inventario/recalcular-costos` | Recalcular costos. | `inventario.costos.recalcular` |
+
 ## SRI
 | Método | Ruta | Descripción | Permiso |
 | ------ | ---- | ----------- | ------- |
@@ -372,7 +444,7 @@ POST /v1/pagos-venta
 - 422 Datos inválidos
 
 ### Matriz RBAC
-| Permiso | admin | supervisor | cajero |
+| Permiso | admin | supervisor | bodega |
 | ------- | ----- | ---------- | ------ |
 | caja.aperturas.crear | ✓ | ✓ | ✓ |
 | caja.aperturas.ver | ✓ | ✓ | ✓ |

--- a/api_registry.json
+++ b/api_registry.json
@@ -362,5 +362,68 @@
     "name": "Webhook SRI",
     "module": "sri",
     "permission": "sri.callback.recibir"
+  },
+  {
+    "method": "GET",
+    "path": "/v1/stock",
+    "name": "Consultar stock",
+    "module": "inventario",
+    "permission": "inventario.stock.ver"
+  },
+  {
+    "method": "POST",
+    "path": "/v1/inventario/ajustes",
+    "name": "Crear ajuste",
+    "module": "inventario",
+    "permission": "inventario.ajustes.crear"
+  },
+  {
+    "method": "POST",
+    "path": "/v1/inventario/transferencias",
+    "name": "Crear transferencia",
+    "module": "inventario",
+    "permission": "inventario.transferencias.crear"
+  },
+  {
+    "method": "POST",
+    "path": "/v1/inventario/transferencias/{id}/recibir",
+    "name": "Recibir transferencia",
+    "module": "inventario",
+    "permission": "inventario.transferencias.recibir"
+  },
+  {
+    "method": "POST",
+    "path": "/v1/inventario/conteos",
+    "name": "Crear conteo",
+    "module": "inventario",
+    "permission": "inventario.conteos.crear"
+  },
+  {
+    "method": "POST",
+    "path": "/v1/inventario/conteos/{id}/cerrar",
+    "name": "Cerrar conteo",
+    "module": "inventario",
+    "permission": "inventario.conteos.cerrar"
+  },
+  {
+    "method": "GET",
+    "path": "/v1/inventario/lotes",
+    "name": "Listar lotes",
+    "module": "inventario",
+    "permission": "inventario.lotes.ver"
+  },
+  {
+    "method": "POST",
+    "path": "/v1/inventario/produccion",
+    "name": "Orden de producción",
+    "module": "inventario",
+    "permission": "inventario.produccion.crear"
+  },
+  {
+    "method": "POST",
+    "path": "/v1/inventario/recalcular-costos",
+    "name": "Recalcular costos",
+    "module": "inventario",
+    "permission": "inventario.costos.recalcular"
   }
 ]

--- a/apis.json
+++ b/apis.json
@@ -3158,6 +3158,176 @@
           }
         }
       ]
+    },
+    {
+      "name": "inventario",
+      "item": [
+        {
+          "name": "GET stock",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/v1/stock",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "stock"
+              ]
+            }
+          }
+        },
+        {
+          "name": "POST inventario/ajustes",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/v1/inventario/ajustes",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "inventario",
+                "ajustes"
+              ]
+            }
+          }
+        },
+        {
+          "name": "POST inventario/transferencias",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/v1/inventario/transferencias",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "inventario",
+                "transferencias"
+              ]
+            }
+          }
+        },
+        {
+          "name": "POST inventario/transferencias/{id}/recibir",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/v1/inventario/transferencias/:id/recibir",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "inventario",
+                "transferencias",
+                ":id",
+                "recibir"
+              ]
+            }
+          }
+        },
+        {
+          "name": "POST inventario/conteos",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/v1/inventario/conteos",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "inventario",
+                "conteos"
+              ]
+            }
+          }
+        },
+        {
+          "name": "POST inventario/conteos/{id}/cerrar",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/v1/inventario/conteos/:id/cerrar",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "inventario",
+                "conteos",
+                ":id",
+                "cerrar"
+              ]
+            }
+          }
+        },
+        {
+          "name": "GET inventario/lotes",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/v1/inventario/lotes",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "inventario",
+                "lotes"
+              ]
+            }
+          }
+        },
+        {
+          "name": "POST inventario/produccion",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/v1/inventario/produccion",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "inventario",
+                "produccion"
+              ]
+            }
+          }
+        },
+        {
+          "name": "POST inventario/recalcular-costos",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/v1/inventario/recalcular-costos",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "inventario",
+                "recalcular-costos"
+              ]
+            }
+          }
+        }
+      ]
     }
   ],
   "variable": [

--- a/app/Http/Controllers/Inventario/AjusteController.php
+++ b/app/Http/Controllers/Inventario/AjusteController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers\Inventario;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class AjusteController extends Controller
+{
+    public function store(Request $request)
+    {
+        return response()->json([
+            'data' => ['id' => 1],
+        ], 201);
+    }
+}

--- a/app/Http/Controllers/Inventario/ConteoController.php
+++ b/app/Http/Controllers/Inventario/ConteoController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Controllers\Inventario;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class ConteoController extends Controller
+{
+    public function index(Request $request)
+    {
+        return response()->json([
+            'data' => [],
+            'meta' => ['page' => 1, 'per_page' => 20, 'total' => 0],
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        return response()->json([
+            'data' => ['conteo_id' => 1, 'estado' => 'abierto'],
+        ], 201);
+    }
+
+    public function show(int $id)
+    {
+        return response()->json([
+            'data' => ['id' => $id, 'estado' => 'abierto', 'diferencias' => []],
+        ]);
+    }
+
+    public function capturas(int $id, Request $request)
+    {
+        return response()->json([
+            'data' => ['capturas' => $request->input('capturas', [])],
+        ], 201);
+    }
+
+    public function cerrar(int $id)
+    {
+        return response()->json([
+            'data' => ['id' => $id, 'sobrantes' => 0, 'faltantes' => 0, 'total_lineas' => 0, 'valores_ajustados' => 0],
+        ]);
+    }
+}

--- a/app/Http/Controllers/Inventario/CostoController.php
+++ b/app/Http/Controllers/Inventario/CostoController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers\Inventario;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class CostoController extends Controller
+{
+    public function show(Request $request)
+    {
+        return response()->json([
+            'data' => [
+                'metodo' => 'PROMEDIO_PONDERADO',
+                'costo_promedio' => 0,
+                'ultimo_costo' => 0,
+                'fecha_ultimo_mov' => now()->toDateString(),
+            ],
+        ]);
+    }
+
+    public function recalcular(Request $request)
+    {
+        return response()->json([
+            'data' => ['tracking_id' => 1],
+        ], 202);
+    }
+}

--- a/app/Http/Controllers/Inventario/LoteController.php
+++ b/app/Http/Controllers/Inventario/LoteController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers\Inventario;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class LoteController extends Controller
+{
+    public function index(Request $request)
+    {
+        return response()->json([
+            'data' => [],
+            'meta' => ['page' => 1, 'per_page' => 20, 'total' => 0],
+        ]);
+    }
+
+    public function alertas(Request $request)
+    {
+        return response()->json([
+            'data' => [],
+            'meta' => ['page' => 1, 'per_page' => 20, 'total' => 0],
+        ]);
+    }
+}

--- a/app/Http/Controllers/Inventario/MermaController.php
+++ b/app/Http/Controllers/Inventario/MermaController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers\Inventario;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class MermaController extends Controller
+{
+    public function store(Request $request)
+    {
+        return response()->json([
+            'data' => ['id' => 1],
+        ], 201);
+    }
+}

--- a/app/Http/Controllers/Inventario/MovimientoController.php
+++ b/app/Http/Controllers/Inventario/MovimientoController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers\Inventario;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class MovimientoController extends Controller
+{
+    public function index(Request $request)
+    {
+        return response()->json([
+            'data' => [],
+            'meta' => ['page' => 1, 'per_page' => 20, 'total' => 0],
+        ]);
+    }
+
+    public function show(int $id)
+    {
+        return response()->json([
+            'data' => ['id' => $id, 'lineas' => []],
+        ]);
+    }
+}

--- a/app/Http/Controllers/Inventario/ProduccionController.php
+++ b/app/Http/Controllers/Inventario/ProduccionController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers\Inventario;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class ProduccionController extends Controller
+{
+    public function store(Request $request)
+    {
+        return response()->json([
+            'data' => ['id' => 1],
+        ], 201);
+    }
+}

--- a/app/Http/Controllers/Inventario/StockController.php
+++ b/app/Http/Controllers/Inventario/StockController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers\Inventario;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class StockController extends Controller
+{
+    public function index(Request $request)
+    {
+        return response()->json([
+            'data' => [],
+            'meta' => ['page' => 1, 'per_page' => 20, 'total' => 0],
+        ]);
+    }
+
+    public function kardex(Request $request)
+    {
+        return response()->json([
+            'data' => [],
+            'meta' => ['page' => 1, 'per_page' => 20, 'total' => 0],
+        ]);
+    }
+}

--- a/app/Http/Controllers/Inventario/TransferenciaController.php
+++ b/app/Http/Controllers/Inventario/TransferenciaController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Controllers\Inventario;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class TransferenciaController extends Controller
+{
+    public function index(Request $request)
+    {
+        return response()->json([
+            'data' => [],
+            'meta' => ['page' => 1, 'per_page' => 20, 'total' => 0],
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        return response()->json([
+            'data' => ['transferencia_id' => 1, 'estado' => 'pendiente'],
+        ], 201);
+    }
+
+    public function show(int $id)
+    {
+        return response()->json([
+            'data' => ['id' => $id, 'estado' => 'pendiente', 'lineas' => []],
+        ]);
+    }
+
+    public function recibir(int $id, Request $request)
+    {
+        return response()->json([
+            'data' => ['id' => $id, 'estado' => 'parcial'],
+        ]);
+    }
+
+    public function cancelar(int $id)
+    {
+        return response()->json([
+            'data' => ['id' => $id, 'estado' => 'cancelada'],
+        ]);
+    }
+}

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -15,6 +15,7 @@ class RolesAndPermissionsSeeder extends Seeder
             ['codigo' => 'ADMIN_LOCAL',   'nombre' => 'Administrador local'],
             ['codigo' => 'MESERO',        'nombre' => 'Mesero'],
             ['codigo' => 'CAJERO',        'nombre' => 'Cajero'],
+            ['codigo' => 'BODEGA',        'nombre' => 'Bodega'],
             ['codigo' => 'COCINA',        'nombre' => 'Cocina'],
         ];
 
@@ -52,6 +53,23 @@ class RolesAndPermissionsSeeder extends Seeder
             ['codigo' => 'productos.ver',                'nombre' => 'Ver productos'],
             ['codigo' => 'productos.crear_editar',       'nombre' => 'Crear/editar productos'],
             ['codigo' => 'inventario.movimientos',       'nombre' => 'Movimientos de inventario'],
+            ['codigo' => 'inventario.stock.ver',         'nombre' => 'Ver stock'],
+            ['codigo' => 'inventario.movimientos.ver',   'nombre' => 'Ver movimientos de inventario'],
+            ['codigo' => 'inventario.ajustes.crear',     'nombre' => 'Crear ajustes de inventario'],
+            ['codigo' => 'inventario.transferencias.crear', 'nombre' => 'Crear transferencias'],
+            ['codigo' => 'inventario.transferencias.ver', 'nombre' => 'Ver transferencias'],
+            ['codigo' => 'inventario.transferencias.recibir', 'nombre' => 'Recibir transferencias'],
+            ['codigo' => 'inventario.transferencias.cancelar', 'nombre' => 'Cancelar transferencias'],
+            ['codigo' => 'inventario.conteos.crear',     'nombre' => 'Crear conteos'],
+            ['codigo' => 'inventario.conteos.capturas',  'nombre' => 'Registrar capturas de conteo'],
+            ['codigo' => 'inventario.conteos.cerrar',    'nombre' => 'Cerrar conteos'],
+            ['codigo' => 'inventario.conteos.ver',       'nombre' => 'Ver conteos'],
+            ['codigo' => 'inventario.lotes.ver',         'nombre' => 'Ver lotes'],
+            ['codigo' => 'inventario.alertas.ver',       'nombre' => 'Ver alertas de inventario'],
+            ['codigo' => 'inventario.produccion.crear',  'nombre' => 'Registrar producción'],
+            ['codigo' => 'inventario.mermas.crear',      'nombre' => 'Registrar mermas'],
+            ['codigo' => 'inventario.costos.ver',        'nombre' => 'Ver costos de inventario'],
+            ['codigo' => 'inventario.costos.recalcular', 'nombre' => 'Recalcular costos de inventario'],
             ['codigo' => 'proveedores.gestionar',        'nombre' => 'Gestionar proveedores'],
             // Pedidos / Cocina
             ['codigo' => 'pedidos.crear',                'nombre' => 'Crear pedidos'],
@@ -109,6 +127,11 @@ class RolesAndPermissionsSeeder extends Seeder
             'ADMIN_LOCAL' => [
                 'usuarios.ver','usuarios.editar','roles.ver','permisos.ver',
                 'config.usuarios.gestionar','productos.ver','productos.crear_editar','inventario.movimientos',
+                'inventario.stock.ver','inventario.movimientos.ver','inventario.ajustes.crear',
+                'inventario.transferencias.crear','inventario.transferencias.ver','inventario.transferencias.recibir',
+                'inventario.transferencias.cancelar','inventario.conteos.crear','inventario.conteos.capturas',
+                'inventario.conteos.cerrar','inventario.conteos.ver','inventario.lotes.ver','inventario.alertas.ver',
+                'inventario.produccion.crear','inventario.mermas.crear','inventario.costos.ver','inventario.costos.recalcular',
                 'proveedores.gestionar','pedidos.crear','cocina.ver','caja.cobrar','caja.cierres',
                 'ventas.facturacion','reportes.ver','reservas.gestionar','cotizaciones.gestionar',
                 'caja.aperturas.crear','caja.aperturas.ver','caja.movimientos.crear','caja.depositos.crear',
@@ -118,6 +141,13 @@ class RolesAndPermissionsSeeder extends Seeder
                 'sri.firma.configurar','sri.firma.ver','sri.secuencias.ver','sri.secuencias.next',
                 'sri.establecimientos.ver','sri.establecimientos.crear','sri.establecimientos.editar','sri.establecimientos.eliminar',
                 'sri.estados.ver','sri.callback.recibir'
+            ],
+            'BODEGA'      => [
+                'inventario.stock.ver','inventario.movimientos.ver','inventario.ajustes.crear',
+                'inventario.transferencias.crear','inventario.transferencias.ver','inventario.transferencias.recibir',
+                'inventario.transferencias.cancelar','inventario.conteos.crear','inventario.conteos.capturas',
+                'inventario.conteos.cerrar','inventario.conteos.ver','inventario.lotes.ver','inventario.alertas.ver',
+                'inventario.produccion.crear','inventario.mermas.crear','inventario.costos.ver','inventario.costos.recalcular'
             ],
             'MESERO'      => ['pedidos.crear','productos.ver','reservas.gestionar'],
             'CAJERO'      => ['caja.cobrar','caja.cierres','ventas.facturacion','reportes.ver',

--- a/routes/api.php
+++ b/routes/api.php
@@ -42,6 +42,15 @@ use App\Http\Controllers\CajaDepositoController;
 use App\Http\Controllers\CajaCierreController;
 use App\Http\Controllers\CajaEstadoController;
 use App\Http\Controllers\PagoVentaController;
+use App\Http\Controllers\Inventario\StockController;
+use App\Http\Controllers\Inventario\MovimientoController;
+use App\Http\Controllers\Inventario\AjusteController;
+use App\Http\Controllers\Inventario\TransferenciaController;
+use App\Http\Controllers\Inventario\ConteoController;
+use App\Http\Controllers\Inventario\LoteController;
+use App\Http\Controllers\Inventario\ProduccionController;
+use App\Http\Controllers\Inventario\MermaController;
+use App\Http\Controllers\Inventario\CostoController;
 
 Route::prefix('v1/auth')->group(function () {
     Route::post('/login', [AuthController::class, 'login']);
@@ -197,6 +206,36 @@ Route::prefix('v1')->middleware('auth.jwt')->group(function () {
         Route::get('/ventas/notas-credito/{id}', [NotaCreditoController::class,'show']);
         Route::post('/ventas/notas-credito/{id}/aplicar', [NotaCreditoController::class,'aplicar']);
         Route::post('/ventas/notas-credito/{id}/anular', [NotaCreditoController::class,'anular']);
+
+        // Inventario
+        Route::get('/stock', [StockController::class, 'index'])->middleware('can:inventario.stock.ver');
+        Route::get('/stock/kardex', [StockController::class, 'kardex'])->middleware('can:inventario.stock.ver');
+
+        Route::get('/inventario/movimientos', [MovimientoController::class, 'index'])->middleware('can:inventario.movimientos.ver');
+        Route::get('/inventario/movimientos/{id}', [MovimientoController::class, 'show'])->middleware('can:inventario.movimientos.ver');
+
+        Route::post('/inventario/ajustes', [AjusteController::class, 'store'])->middleware('can:inventario.ajustes.crear');
+
+        Route::post('/inventario/transferencias', [TransferenciaController::class, 'store'])->middleware('can:inventario.transferencias.crear');
+        Route::get('/inventario/transferencias', [TransferenciaController::class, 'index'])->middleware('can:inventario.transferencias.ver');
+        Route::get('/inventario/transferencias/{id}', [TransferenciaController::class, 'show'])->middleware('can:inventario.transferencias.ver');
+        Route::post('/inventario/transferencias/{id}/recibir', [TransferenciaController::class, 'recibir'])->middleware('can:inventario.transferencias.recibir');
+        Route::post('/inventario/transferencias/{id}/cancelar', [TransferenciaController::class, 'cancelar'])->middleware('can:inventario.transferencias.cancelar');
+
+        Route::post('/inventario/conteos', [ConteoController::class, 'store'])->middleware('can:inventario.conteos.crear');
+        Route::post('/inventario/conteos/{id}/capturas', [ConteoController::class, 'capturas'])->middleware('can:inventario.conteos.capturas');
+        Route::post('/inventario/conteos/{id}/cerrar', [ConteoController::class, 'cerrar'])->middleware('can:inventario.conteos.cerrar');
+        Route::get('/inventario/conteos', [ConteoController::class, 'index'])->middleware('can:inventario.conteos.ver');
+        Route::get('/inventario/conteos/{id}', [ConteoController::class, 'show'])->middleware('can:inventario.conteos.ver');
+
+        Route::get('/inventario/lotes', [LoteController::class, 'index'])->middleware('can:inventario.lotes.ver');
+        Route::get('/inventario/alertas', [LoteController::class, 'alertas'])->middleware('can:inventario.alertas.ver');
+
+        Route::post('/inventario/produccion', [ProduccionController::class, 'store'])->middleware('can:inventario.produccion.crear');
+        Route::post('/inventario/mermas', [MermaController::class, 'store'])->middleware('can:inventario.mermas.crear');
+
+        Route::get('/inventario/costos', [CostoController::class, 'show'])->middleware('can:inventario.costos.ver');
+        Route::post('/inventario/recalcular-costos', [CostoController::class, 'recalcular'])->middleware('can:inventario.costos.recalcular');
 
         // Facturas electrónicas
         Route::get('/facturas', [FacturaElectronicaController::class,'index'])->middleware('can:facturas.ver');

--- a/tests/Feature/InventarioAuthTest.php
+++ b/tests/Feature/InventarioAuthTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class InventarioAuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_stock_requires_auth(): void
+    {
+        $this->getJson('/v1/stock')->assertStatus(401);
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold inventory controllers, routes and permissions
- document inventory endpoints and RBAC matrix
- register inventory APIs in registry and Postman collection

## Testing
- `composer install` *(fails: CONNECT tunnel failed, requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68a368370628832f932fd8d864d53e08