### PR TITLE
feat: add basic configuration endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,38 @@ Puedes importar el archivo `apis.json` en Postman para probar todos los endpoint
 | ------ | ---- | ----------- |
 | GET | `/v1/menu` | Devuelve la estructura del menú principal. |
 
+## Configuración
+### Empresa
+| Método | Ruta | Descripción | Permiso |
+| ------ | ---- | ----------- | ------- |
+| GET | `/v1/config/empresa` | Obtener parámetros generales de la empresa | `config.ver` |
+| PUT | `/v1/config/empresa` | Actualizar parámetros generales de la empresa | `config.editar` |
+
+Ejemplo:
+
+`PUT /v1/config/empresa`
+```json
+{
+  "nombre_comercial": "Mi Restaurante"
+}
+```
+Respuesta:
+```json
+{
+  "data": {
+    "nombre_comercial": "Mi Restaurante"
+  }
+}
+```
+
+### Locales
+| Método | Ruta | Descripción | Permiso |
+| ------ | ---- | ----------- | ------- |
+| GET | `/v1/locales/{id}/config` | Obtener configuración de un local | `locales.config.ver` |
+| PUT | `/v1/locales/{id}/config` | Actualizar configuración de un local | `locales.config.editar` |
+
+Nota: la configuración definida en un local prevalece sobre la configuración de la empresa cuando exista.
+
 ## Pedidos
 | Método | Ruta | Descripción |
 | ------ | ---- | ----------- |
@@ -563,6 +595,10 @@ Nota: se mantiene alias `POST /v1/pagos-proveedor` (deprecado).
 ### Matriz RBAC
 | Permiso | admin | supervisor | bodega |
 | ------- | ----- | ---------- | ------ |
+| config.ver | ✓ | ✓ | — |
+| config.editar | ✓ | ✓ | — |
+| locales.config.ver | ✓ | ✓ | — |
+| locales.config.editar | ✓ | ✓ | — |
 | caja.aperturas.crear | ✓ | ✓ | ✓ |
 | caja.aperturas.ver | ✓ | ✓ | ✓ |
 | caja.movimientos.crear | ✓ | ✓ | ✓ |

--- a/api_registry.json
+++ b/api_registry.json
@@ -656,5 +656,33 @@
     "name": "Importar settlements tarjetas",
     "module": "tesoreria",
     "permission": "tesoreria.tarjetas.ver"
+  },
+  {
+    "method": "GET",
+    "path": "/v1/config/empresa",
+    "name": "Ver config empresa",
+    "module": "config",
+    "permission": "config.ver"
+  },
+  {
+    "method": "PUT",
+    "path": "/v1/config/empresa",
+    "name": "Actualizar config empresa",
+    "module": "config",
+    "permission": "config.editar"
+  },
+  {
+    "method": "GET",
+    "path": "/v1/locales/{id}/config",
+    "name": "Ver config local",
+    "module": "locales",
+    "permission": "locales.config.ver"
+  },
+  {
+    "method": "PUT",
+    "path": "/v1/locales/{id}/config",
+    "name": "Actualizar config local",
+    "module": "locales",
+    "permission": "locales.config.editar"
   }
 ]

--- a/apis.json
+++ b/apis.json
@@ -3712,6 +3712,92 @@
           }
         }
       ]
+    },
+    {
+      "name": "config",
+      "item": [
+        {
+          "name": "GET config empresa",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/v1/config/empresa",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "v1",
+                "config",
+                "empresa"
+              ]
+            }
+          }
+        },
+        {
+          "name": "PUT config empresa",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {"key": "Authorization", "value": "Bearer {{token}}"},
+              {"key": "Content-Type", "value": "application/json"}
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"nombre_comercial\": \"Mi Restaurante\"\n}",
+              "options": {
+                "raw": {"language": "json"}
+              }
+            },
+            "url": {
+              "raw": "{{base_url}}/v1/config/empresa",
+              "host": ["{{base_url}}"],
+              "path": ["v1","config","empresa"]
+            }
+          }
+        },
+        {
+          "name": "GET config local",
+          "request": {
+            "method": "GET",
+            "header": [
+              {"key": "Authorization", "value": "Bearer {{token}}"}
+            ],
+            "url": {
+              "raw": "{{base_url}}/v1/locales/1/config",
+              "host": ["{{base_url}}"],
+              "path": ["v1","locales","1","config"]
+            }
+          }
+        },
+        {
+          "name": "PUT config local",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {"key": "Authorization", "value": "Bearer {{token}}"},
+              {"key": "Content-Type", "value": "application/json"}
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"propina_por_defecto\": 10\n}",
+              "options": {
+                "raw": {"language": "json"}
+              }
+            },
+            "url": {
+              "raw": "{{base_url}}/v1/locales/1/config",
+              "host": ["{{base_url}}"],
+              "path": ["v1","locales","1","config"]
+            }
+          }
+        }
+      ]
     }
   ],
   "variable": [

--- a/app/Http/Controllers/ConfigEmpresaController.php
+++ b/app/Http/Controllers/ConfigEmpresaController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+
+class ConfigEmpresaController extends Controller
+{
+    public function show()
+    {
+        $row = DB::selectOne("SELECT config FROM config_empresa WHERE id = 1");
+        $config = $row ? json_decode($row->config, true) : [];
+        return ['data' => $config];
+    }
+
+    public function update(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'nombre_comercial' => 'nullable|string',
+            'moneda' => 'nullable|string',
+            'iva_incluido' => 'boolean',
+            'redondeo_regla' => 'nullable|string',
+            'propina_por_defecto' => 'numeric|between:0,100',
+            'servicio_por_defecto' => 'numeric|between:0,100',
+            'politica_stock_negativo' => 'boolean',
+            'metodo_valuacion' => 'nullable|string',
+            'exige_lote_caducidad' => 'boolean',
+            'politica_seguridad' => 'array',
+            'branding' => 'array',
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => $validator->errors()->toArray(),
+            ], 422);
+        }
+        $data = $validator->validated();
+        $json = json_encode($data);
+        $exists = DB::selectOne("SELECT id FROM config_empresa WHERE id = 1");
+        if ($exists) {
+            DB::update(
+                "UPDATE config_empresa SET config = :config, updated_by = :user, updated_at = CURRENT_TIMESTAMP WHERE id = 1",
+                ['config' => $json, 'user' => $request->user()->id ?? null]
+            );
+        } else {
+            DB::insert(
+                "INSERT INTO config_empresa (id, config, updated_by, created_at, updated_at) VALUES (1, :config, :user, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                ['config' => $json, 'user' => $request->user()->id ?? null]
+            );
+        }
+        return ['data' => $data];
+    }
+}
+

--- a/app/Http/Controllers/ConfigLocalController.php
+++ b/app/Http/Controllers/ConfigLocalController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+
+class ConfigLocalController extends Controller
+{
+    public function show($id)
+    {
+        $row = DB::selectOne("SELECT config FROM config_local WHERE local_id = :id", ['id' => $id]);
+        $config = $row ? json_decode($row->config, true) : [];
+        return ['data' => $config];
+    }
+
+    public function update(Request $request, $id)
+    {
+        $validator = Validator::make($request->all(), [
+            'iva_incluido' => 'boolean',
+            'propina_por_defecto' => 'numeric|between:0,100',
+            'servicio_por_defecto' => 'numeric|between:0,100',
+            'punto_emision' => 'nullable|string',
+            'establecimiento' => 'nullable|string',
+            'horarios' => 'array',
+            'aforo' => 'integer',
+            'kds_ruteo' => 'array',
+            'impresoras' => 'array',
+            'metodos_pago_habilitados' => 'array',
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => $validator->errors()->toArray(),
+            ], 422);
+        }
+        $data = $validator->validated();
+        $json = json_encode($data);
+        $exists = DB::selectOne("SELECT local_id FROM config_local WHERE local_id = :id", ['id' => $id]);
+        if ($exists) {
+            DB::update(
+                "UPDATE config_local SET config = :config, updated_by = :user, updated_at = CURRENT_TIMESTAMP WHERE local_id = :id",
+                ['config' => $json, 'user' => $request->user()->id ?? null, 'id' => $id]
+            );
+        } else {
+            DB::insert(
+                "INSERT INTO config_local (local_id, config, updated_by, created_at, updated_at) VALUES (:id, :config, :user, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                ['id' => $id, 'config' => $json, 'user' => $request->user()->id ?? null]
+            );
+        }
+        return ['data' => $data];
+    }
+}
+

--- a/app/Models/ConfigEmpresa.php
+++ b/app/Models/ConfigEmpresa.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ConfigEmpresa extends Model
+{
+    protected $table = 'config_empresa';
+    protected $fillable = ['config', 'updated_by'];
+    protected $casts = [
+        'config' => 'array',
+    ];
+}
+

--- a/app/Models/ConfigLocal.php
+++ b/app/Models/ConfigLocal.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ConfigLocal extends Model
+{
+    protected $table = 'config_local';
+    protected $primaryKey = 'local_id';
+    public $incrementing = false;
+    protected $fillable = ['local_id','config','updated_by'];
+    protected $casts = [
+        'config' => 'array',
+    ];
+}
+

--- a/database/migrations/2025_09_17_000001_create_config_empresa_table.php
+++ b/database/migrations/2025_09_17_000001_create_config_empresa_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('config_empresa', function (Blueprint $table) {
+            $table->id();
+            $table->json('config')->nullable();
+            $table->unsignedBigInteger('updated_by')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('config_empresa');
+    }
+};
+

--- a/database/migrations/2025_09_17_000002_create_config_local_table.php
+++ b/database/migrations/2025_09_17_000002_create_config_local_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('config_local', function (Blueprint $table) {
+            $table->unsignedBigInteger('local_id')->primary();
+            $table->json('config')->nullable();
+            $table->unsignedBigInteger('updated_by')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('config_local');
+    }
+};
+

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -51,6 +51,10 @@ class RolesAndPermissionsSeeder extends Seeder
             ['codigo' => 'config.locales.gestionar',     'nombre' => 'Gestionar locales'],
             ['codigo' => 'config.usuarios.gestionar',    'nombre' => 'Gestionar usuarios'],
             ['codigo' => 'config.roles.permisos',        'nombre' => 'Gestionar roles y permisos'],
+            ['codigo' => 'config.ver',                   'nombre' => 'Ver configuración empresa'],
+            ['codigo' => 'config.editar',                'nombre' => 'Editar configuración empresa'],
+            ['codigo' => 'locales.config.ver',           'nombre' => 'Ver configuración local'],
+            ['codigo' => 'locales.config.editar',        'nombre' => 'Editar configuración local'],
             // Productos / Inventario
             ['codigo' => 'productos.ver',                'nombre' => 'Ver productos'],
             ['codigo' => 'productos.crear_editar',       'nombre' => 'Crear/editar productos'],
@@ -171,7 +175,8 @@ class RolesAndPermissionsSeeder extends Seeder
             'SUPER_ADMIN' => array_column($permisos, 'codigo'),
             'ADMIN_LOCAL' => [
                 'usuarios.ver','usuarios.editar','roles.ver','permisos.ver',
-                'config.usuarios.gestionar','productos.ver','productos.crear_editar','inventario.movimientos',
+                'config.usuarios.gestionar','config.ver','config.editar','locales.config.ver','locales.config.editar',
+                'productos.ver','productos.crear_editar','inventario.movimientos',
                 'inventario.stock.ver','inventario.movimientos.ver','inventario.ajustes.crear',
                 'inventario.transferencias.crear','inventario.transferencias.ver','inventario.transferencias.recibir',
                 'inventario.transferencias.cancelar','inventario.conteos.crear','inventario.conteos.capturas',

--- a/routes/api.php
+++ b/routes/api.php
@@ -25,6 +25,8 @@ use App\Http\Controllers\PagoProveedorController;
 use App\Http\Controllers\Tesoreria\CuentaBancariaController;
 use App\Http\Controllers\Tesoreria\ConciliacionController;
 use App\Http\Controllers\Tesoreria\TarjetaSettlementController;
+use App\Http\Controllers\ConfigEmpresaController;
+use App\Http\Controllers\ConfigLocalController;
 use App\Http\Controllers\MenuController;
 use App\Http\Controllers\PedidoController;
 use App\Http\Controllers\ReservaController;
@@ -87,6 +89,10 @@ Route::prefix('v1')->group(function () {
 
 Route::prefix('v1')->middleware('auth.jwt')->group(function () {
     Route::middleware('check.subscription')->group(function () {
+        Route::get('/config/empresa', [ConfigEmpresaController::class, 'show'])->middleware('can:config.ver');
+        Route::put('/config/empresa', [ConfigEmpresaController::class, 'update'])->middleware('can:config.editar');
+        Route::get('/locales/{id}/config', [ConfigLocalController::class, 'show'])->middleware('can:locales.config.ver');
+        Route::put('/locales/{id}/config', [ConfigLocalController::class, 'update'])->middleware('can:locales.config.editar');
         Route::get('/empresas', [EmpresaController::class, 'index']);
         Route::post('/empresas', [EmpresaController::class, 'store']);
         Route::get('/empresas/{id}', [EmpresaController::class, 'show']);


### PR DESCRIPTION
## Summary
- add controllers and routes for company and local configuration
- seed RBAC permissions and document new endpoints
- include migration and Postman entries

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68a38d13df90832f943f7e6be9ed3388