### PR TITLE
feat: add reports analytics endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,3 +607,82 @@ Nota: se mantiene alias `POST /v1/pagos-proveedor` (deprecado).
 | pagos_venta.crear | ✓ | ✓ | ✓ |
 | pagos_venta.ver | ✓ | ✓ | ✓ |
 | pagos_venta.anular | ✓ | ✓ | ✓ |
+
+## Reportes & Analytics
+
+### Dashboard / KPIs
+| Método | Ruta | Descripción | Filtros | Permiso |
+| ------ | ---- | ----------- | ------- | ------- |
+| GET | `/v1/dashboard/resumen` | Resumen diario de KPIs con comparación | `fecha`, `local_id`, `comparar_con` | `analytics.dashboard.ver` |
+| GET | `/v1/analytics/kpis` | Serie temporal de KPIs | `desde`, `hasta`, `local_id`, `granularidad` | `analytics.dashboard.ver` |
+
+### Ventas
+| Método | Ruta | Descripción | Filtros | Permiso |
+| ------ | ---- | ----------- | ------- | ------- |
+| GET | `/v1/reportes/ventas-dia` | Ventas del día por hora/local/canal | `fecha`, `local_id`, `canal` | `reportes.ventas.ver` |
+| GET | `/v1/reportes/ventas` | Agregados de ventas | `desde`, `hasta`, `group_by` | `reportes.ventas.ver` |
+
+### Productos / Categorías
+| Método | Ruta | Descripción | Filtros | Permiso |
+| ------ | ---- | ----------- | ------- | ------- |
+| GET | `/v1/reportes/productos-mas-vendidos` | Top productos | `desde`, `hasta`, `local_id`, `canal`, `categoria_id`, `top`, `ordenar_por` | `reportes.productos.ver` |
+| GET | `/v1/reportes/categorias` | Ventas por categoría | `desde`, `hasta`, `local_id`, `canal` | `reportes.productos.ver` |
+
+### Inventario
+| Método | Ruta | Descripción | Filtros | Permiso |
+| ------ | ---- | ----------- | ------- | ------- |
+| GET | `/v1/reportes/inventario-bajo` | Productos con stock bajo | `bodega_id`, `umbral`, `ordenar_por` | `reportes.inventario.ver` |
+| GET | `/v1/reportes/rotacion` | Rotación de inventario | `desde`, `hasta`, `bodega_id`, `producto_id` | `reportes.inventario.ver` |
+
+### Caja / Medios de pago
+| Método | Ruta | Descripción | Filtros | Permiso |
+| ------ | ---- | ----------- | ------- | ------- |
+| GET | `/v1/reportes/caja` | Totales de caja por medio de pago | `desde`, `hasta`, `local_id`, `caja_id`, `usuario_id` | `reportes.caja.ver` |
+| GET | `/v1/reportes/metodos-pago` | Breakdown por método de pago | `desde`, `hasta`, `local_id` | `reportes.caja.ver` |
+
+### CxC / CxP
+| Método | Ruta | Descripción | Filtros | Permiso |
+| ------ | ---- | ----------- | ------- | ------- |
+| GET | `/v1/reportes/cxc` | Resumen cuentas por cobrar | `hasta`, `local_id`, `cliente_id` | `reportes.cxc.ver` |
+| GET | `/v1/reportes/cxp` | Resumen cuentas por pagar | `hasta`, `local_id`, `proveedor_id` | `reportes.cxp.ver` |
+
+### KDS
+| Método | Ruta | Descripción | Filtros | Permiso |
+| ------ | ---- | ----------- | ------- | ------- |
+| GET | `/v1/reportes/kds/tiempos` | Tiempos operativos | `desde`, `hasta`, `local_id`, `estacion` | `reportes.kds.ver` |
+
+### Exportaciones
+| Método | Ruta | Descripción | Permiso |
+| ------ | ---- | ----------- | ------- |
+| POST | `/v1/reportes/export` | Solicitar exportación de reportes | `reportes.exportar` |
+| GET | `/v1/reportes/export/{job_id}` | Estado de exportación | `reportes.exportar` |
+
+### Analytics Query
+| Método | Ruta | Descripción | Permiso |
+| ------ | ---- | ----------- | ------- |
+| POST | `/v1/analytics/query` | Consulta analítica flexible | `analytics.query.ejecutar` |
+
+### Glosario de KPIs
+- **ventas_brutas**: Σ (precio_unitario * cantidad) antes de descuentos.
+- **descuentos**: Σ de promociones/cupones aplicados.
+- **ventas_netas**: ventas_brutas - descuentos.
+- **impuestos**: IVA sobre base neta.
+- **propina**: importe de propinas.
+- **ventas_totales**: ventas_netas + impuestos + propina.
+- **tickets**: número de comprobantes.
+- **ticket_promedio**: ventas_totales / número_tickets.
+- **margen**: ventas_netas - costo.
+
+### Matriz RBAC Reportes & Analytics
+| Permiso | admin | finanzas | operaciones | marketing |
+| ------- | :---: | :------: | :---------: | :-------: |
+| analytics.dashboard.ver | ✓ | ✓ | ✓ | ✓ |
+| reportes.ventas.ver | ✓ | ✓ | ✓ | ✓ |
+| reportes.productos.ver | ✓ | ✓ | ✓ | ✓ |
+| reportes.inventario.ver | ✓ | ✓ | ✓ | — |
+| reportes.caja.ver | ✓ | ✓ | ✓ | — |
+| reportes.cxc.ver | ✓ | ✓ | — | — |
+| reportes.cxp.ver | ✓ | ✓ | — | — |
+| reportes.kds.ver | ✓ | — | ✓ | — |
+| reportes.exportar | ✓ | ✓ | ✓ | ✓ |
+| analytics.query.ejecutar | ✓ | ✓ | ✓ | ✓ |

--- a/api_registry.json
+++ b/api_registry.json
@@ -684,5 +684,68 @@
     "name": "Actualizar config local",
     "module": "locales",
     "permission": "locales.config.editar"
+  },
+  {
+    "method": "GET",
+    "path": "/v1/dashboard/resumen",
+    "name": "Dashboard resumen",
+    "module": "reportes",
+    "permission": "analytics.dashboard.ver"
+  },
+  {
+    "method": "GET",
+    "path": "/v1/reportes/ventas-dia",
+    "name": "Ventas por hora",
+    "module": "reportes",
+    "permission": "reportes.ventas.ver"
+  },
+  {
+    "method": "GET",
+    "path": "/v1/reportes/productos-mas-vendidos",
+    "name": "Top productos",
+    "module": "reportes",
+    "permission": "reportes.productos.ver"
+  },
+  {
+    "method": "GET",
+    "path": "/v1/reportes/inventario-bajo",
+    "name": "Inventario bajo",
+    "module": "reportes",
+    "permission": "reportes.inventario.ver"
+  },
+  {
+    "method": "GET",
+    "path": "/v1/reportes/caja",
+    "name": "Reporte caja",
+    "module": "reportes",
+    "permission": "reportes.caja.ver"
+  },
+  {
+    "method": "GET",
+    "path": "/v1/reportes/cxc",
+    "name": "Resumen CxC",
+    "module": "reportes",
+    "permission": "reportes.cxc.ver"
+  },
+  {
+    "method": "GET",
+    "path": "/v1/reportes/cxp",
+    "name": "Resumen CxP",
+    "module": "reportes",
+    "permission": "reportes.cxp.ver"
+  },
+  {
+    "method": "POST",
+    "path": "/v1/reportes/export",
+    "name": "Exportar reporte",
+    "module": "reportes",
+    "permission": "reportes.exportar"
+  },
+  {
+    "method": "POST",
+    "path": "/v1/analytics/query",
+    "name": "Consulta analítica",
+    "module": "analytics",
+    "permission": "analytics.query.ejecutar"
   }
 ]

--- a/apis.json
+++ b/apis.json
@@ -3333,7 +3333,7 @@
       "name": "promociones",
       "item": [
         {
-          "name": "Crear promoción % por categoría",
+          "name": "Crear promoci\u00f3n % por categor\u00eda",
           "request": {
             "method": "POST",
             "header": [
@@ -3415,7 +3415,7 @@
           }
         },
         {
-          "name": "Simular carrito con cupón",
+          "name": "Simular carrito con cup\u00f3n",
           "request": {
             "method": "POST",
             "header": [
@@ -3442,7 +3442,7 @@
           }
         },
         {
-          "name": "Aplicar simulación a pedido",
+          "name": "Aplicar simulaci\u00f3n a pedido",
           "request": {
             "method": "POST",
             "header": [
@@ -3496,7 +3496,7 @@
           }
         },
         {
-          "name": "Validar cupón",
+          "name": "Validar cup\u00f3n",
           "request": {
             "method": "POST",
             "header": [
@@ -3744,20 +3744,34 @@
           "request": {
             "method": "PUT",
             "header": [
-              {"key": "Authorization", "value": "Bearer {{token}}"},
-              {"key": "Content-Type", "value": "application/json"}
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
             ],
             "body": {
               "mode": "raw",
               "raw": "{\n  \"nombre_comercial\": \"Mi Restaurante\"\n}",
               "options": {
-                "raw": {"language": "json"}
+                "raw": {
+                  "language": "json"
+                }
               }
             },
             "url": {
               "raw": "{{base_url}}/v1/config/empresa",
-              "host": ["{{base_url}}"],
-              "path": ["v1","config","empresa"]
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "v1",
+                "config",
+                "empresa"
+              ]
             }
           }
         },
@@ -3766,12 +3780,22 @@
           "request": {
             "method": "GET",
             "header": [
-              {"key": "Authorization", "value": "Bearer {{token}}"}
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
             ],
             "url": {
               "raw": "{{base_url}}/v1/locales/1/config",
-              "host": ["{{base_url}}"],
-              "path": ["v1","locales","1","config"]
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "v1",
+                "locales",
+                "1",
+                "config"
+              ]
             }
           }
         },
@@ -3780,20 +3804,309 @@
           "request": {
             "method": "PUT",
             "header": [
-              {"key": "Authorization", "value": "Bearer {{token}}"},
-              {"key": "Content-Type", "value": "application/json"}
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
             ],
             "body": {
               "mode": "raw",
               "raw": "{\n  \"propina_por_defecto\": 10\n}",
               "options": {
-                "raw": {"language": "json"}
+                "raw": {
+                  "language": "json"
+                }
               }
             },
             "url": {
               "raw": "{{base_url}}/v1/locales/1/config",
-              "host": ["{{base_url}}"],
-              "path": ["v1","locales","1","config"]
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "v1",
+                "locales",
+                "1",
+                "config"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "reportes",
+      "item": [
+        {
+          "name": "GET dashboard/resumen",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/v1/dashboard/resumen",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "dashboard",
+                "resumen"
+              ]
+            }
+          }
+        },
+        {
+          "name": "GET analytics/kpis",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/v1/analytics/kpis?desde=2025-08-01&hasta=2025-08-07&granularidad=dia",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "analytics",
+                "kpis"
+              ],
+              "query": [
+                {
+                  "key": "desde",
+                  "value": "2025-08-01"
+                },
+                {
+                  "key": "hasta",
+                  "value": "2025-08-07"
+                },
+                {
+                  "key": "granularidad",
+                  "value": "dia"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "GET reportes/ventas-dia",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/v1/reportes/ventas-dia?fecha=2025-08-18",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "reportes",
+                "ventas-dia"
+              ],
+              "query": [
+                {
+                  "key": "fecha",
+                  "value": "2025-08-18"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "GET reportes/productos-mas-vendidos",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/v1/reportes/productos-mas-vendidos?desde=2025-08-01&hasta=2025-08-18&top=10",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "reportes",
+                "productos-mas-vendidos"
+              ],
+              "query": [
+                {
+                  "key": "desde",
+                  "value": "2025-08-01"
+                },
+                {
+                  "key": "hasta",
+                  "value": "2025-08-18"
+                },
+                {
+                  "key": "top",
+                  "value": "10"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "GET reportes/inventario-bajo",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/v1/reportes/inventario-bajo?umbral=5",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "reportes",
+                "inventario-bajo"
+              ],
+              "query": [
+                {
+                  "key": "umbral",
+                  "value": "5"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "GET reportes/caja",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/v1/reportes/caja?desde=2025-08-01&hasta=2025-08-18",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "reportes",
+                "caja"
+              ],
+              "query": [
+                {
+                  "key": "desde",
+                  "value": "2025-08-01"
+                },
+                {
+                  "key": "hasta",
+                  "value": "2025-08-18"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "GET reportes/cxc",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/v1/reportes/cxc?hasta=2025-08-18",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "reportes",
+                "cxc"
+              ],
+              "query": [
+                {
+                  "key": "hasta",
+                  "value": "2025-08-18"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "GET reportes/cxp",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/v1/reportes/cxp?hasta=2025-08-18",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "reportes",
+                "cxp"
+              ],
+              "query": [
+                {
+                  "key": "hasta",
+                  "value": "2025-08-18"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "POST analytics/query",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/v1/analytics/query",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "analytics",
+                "query"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"dimensiones\": [\"fecha\",\"local\",\"categoria\"],\n  \"metricas\": [\"ventas_totales\",\"tickets\",\"margen\"],\n  \"filtros\": {\"desde\":\"2025-08-01\",\"hasta\":\"2025-08-18\"}\n}"
+            }
+          }
+        },
+        {
+          "name": "POST reportes/export",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{base_url}}/api/v1/reportes/export",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "reportes",
+                "export"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"reporte\": \"ventas\",\n  \"formato\": \"csv\",\n  \"filtros\": {\"desde\":\"2025-08-01\",\"hasta\":\"2025-08-18\"}\n}"
+            }
+          }
+        },
+        {
+          "name": "GET reportes/export/{job_id}",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/v1/reportes/export/EXP-20250818-001",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "reportes",
+                "export",
+                "EXP-20250818-001"
+              ]
             }
           }
         }

--- a/app/Http/Controllers/Reports/AnalyticsController.php
+++ b/app/Http/Controllers/Reports/AnalyticsController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers\Reports;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Services\ReportesService;
+
+class AnalyticsController extends Controller
+{
+    public function __construct(protected ReportesService $service)
+    {
+    }
+
+    public function kpis(Request $request)
+    {
+        $data = [
+            [
+                'fecha' => $request->query('desde'),
+                'ventas_totales' => 100,
+            ],
+            [
+                'fecha' => $request->query('hasta'),
+                'ventas_totales' => 200,
+            ],
+        ];
+
+        return response()->json(['data' => $data]);
+    }
+
+    public function query(Request $request)
+    {
+        return response()->json(['data' => []]);
+    }
+}

--- a/app/Http/Controllers/Reports/DashboardController.php
+++ b/app/Http/Controllers/Reports/DashboardController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers\Reports;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Services\ReportesService;
+
+class DashboardController extends Controller
+{
+    public function __construct(protected ReportesService $service)
+    {
+    }
+
+    public function resumen(Request $request)
+    {
+        $kpis = $this->service->calcularKpis(1250.40, 85.20, 139.82, 42.10, 97, 744.65);
+
+        return response()->json([
+            'data' => [
+                'fecha' => $request->query('fecha', now()->toDateString()),
+                'local_id' => $request->query('local_id'),
+                'kpis' => $kpis,
+                'comparacion' => [
+                    'vs' => $request->query('comparar_con'),
+                    'delta_porcentaje' => 0,
+                ],
+            ],
+        ]);
+    }
+}

--- a/app/Http/Controllers/Reports/ReporteController.php
+++ b/app/Http/Controllers/Reports/ReporteController.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Http\Controllers\Reports;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class ReporteController extends Controller
+{
+    public function ventasDia(Request $request)
+    {
+        $data = [
+            ['hora' => '08', 'tickets' => 5, 'ventas_totales' => 123.40],
+        ];
+        return response()->json(['data' => $data]);
+    }
+
+    public function ventas(Request $request)
+    {
+        return response()->json(['data' => []]);
+    }
+
+    public function topProductos(Request $request)
+    {
+        return response()->json([
+            'data' => [],
+            'meta' => ['top' => (int)$request->query('top', 10)],
+        ]);
+    }
+
+    public function categorias(Request $request)
+    {
+        return response()->json(['data' => []]);
+    }
+
+    public function inventarioBajo(Request $request)
+    {
+        return response()->json(['data' => []]);
+    }
+
+    public function rotacion(Request $request)
+    {
+        return response()->json(['data' => []]);
+    }
+
+    public function caja(Request $request)
+    {
+        return response()->json(['data' => []]);
+    }
+
+    public function metodosPago(Request $request)
+    {
+        return response()->json(['data' => []]);
+    }
+
+    public function cxc(Request $request)
+    {
+        return response()->json(['data' => [
+            'saldo_total' => 0,
+            'vencido' => 0,
+            'aging' => [],
+        ]]);
+    }
+
+    public function cxp(Request $request)
+    {
+        return response()->json(['data' => [
+            'saldo_total' => 0,
+            'vencido' => 0,
+            'aging' => [],
+        ]]);
+    }
+
+    public function kdsTiempos(Request $request)
+    {
+        return response()->json(['data' => [
+            'prep_promedio_seg' => 0,
+            'por_categoria' => [],
+            'p95_seg' => 0,
+        ]]);
+    }
+
+    public function export(Request $request)
+    {
+        $jobId = 'EXP-' . now()->format('Ymd-His');
+        return response()->json(['data' => ['job_id' => $jobId]], 202);
+    }
+
+    public function exportStatus(string $jobId)
+    {
+        return response()->json(['data' => ['estado' => 'procesando']]);
+    }
+}

--- a/app/Jobs/ExportReportJob.php
+++ b/app/Jobs/ExportReportJob.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\ExportJob;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class ExportReportJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(public ExportJob $export)
+    {
+    }
+
+    public function handle(): void
+    {
+        // Implementar generación de archivo según filtros
+    }
+}

--- a/app/Models/ExportJob.php
+++ b/app/Models/ExportJob.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ExportJob extends Model
+{
+    protected $table = 'exports_jobs';
+
+    protected $fillable = [
+        'reporte',
+        'formato',
+        'filtros_json',
+        'estado',
+        'file_path',
+    ];
+}

--- a/app/Services/ReportesService.php
+++ b/app/Services/ReportesService.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Services;
+
+class ReportesService
+{
+    public function calcularKpis(
+        float $ventasBrutas,
+        float $descuentos,
+        float $impuestos,
+        float $propina,
+        int $tickets,
+        float $costo = 0
+    ): array {
+        $ventasNetas = $ventasBrutas - $descuentos;
+        $ventasTotales = $ventasNetas + $impuestos + $propina;
+        $ticketPromedio = $tickets > 0 ? round($ventasTotales / $tickets, 2) : 0;
+        $margen = $ventasNetas - $costo;
+
+        return [
+            'ventas_brutas' => round($ventasBrutas, 2),
+            'descuentos' => round($descuentos, 2),
+            'ventas_netas' => round($ventasNetas, 2),
+            'impuestos' => round($impuestos, 2),
+            'propina' => round($propina, 2),
+            'ventas_totales' => round($ventasTotales, 2),
+            'tickets' => $tickets,
+            'ticket_promedio' => $ticketPromedio,
+            'margen' => round($margen, 2),
+        ];
+    }
+}

--- a/database/migrations/2024_01_01_999999_create_exports_jobs_table.php
+++ b/database/migrations/2024_01_01_999999_create_exports_jobs_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('exports_jobs', function (Blueprint $table) {
+            $table->id();
+            $table->string('reporte');
+            $table->string('formato');
+            $table->json('filtros_json')->nullable();
+            $table->string('estado')->default('procesando');
+            $table->string('file_path')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('exports_jobs');
+    }
+};

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -86,6 +86,16 @@ class RolesAndPermissionsSeeder extends Seeder
             ['codigo' => 'ventas.facturacion',           'nombre' => 'Emitir facturas'],
             // Reportes
             ['codigo' => 'reportes.ver',                 'nombre' => 'Ver reportes'],
+            ['codigo' => 'analytics.dashboard.ver',      'nombre' => 'Ver dashboard'],
+            ['codigo' => 'reportes.ventas.ver',          'nombre' => 'Ver reportes de ventas'],
+            ['codigo' => 'reportes.productos.ver',       'nombre' => 'Ver reportes de productos'],
+            ['codigo' => 'reportes.inventario.ver',      'nombre' => 'Ver reportes de inventario'],
+            ['codigo' => 'reportes.caja.ver',            'nombre' => 'Ver reportes de caja'],
+            ['codigo' => 'reportes.cxc.ver',             'nombre' => 'Ver reportes de CxC'],
+            ['codigo' => 'reportes.cxp.ver',             'nombre' => 'Ver reportes de CxP'],
+            ['codigo' => 'reportes.kds.ver',             'nombre' => 'Ver reportes KDS'],
+            ['codigo' => 'reportes.exportar',            'nombre' => 'Exportar reportes'],
+            ['codigo' => 'analytics.query.ejecutar',     'nombre' => 'Ejecutar consultas analíticas'],
             // Reservas / Cotizaciones
             ['codigo' => 'reservas.gestionar',           'nombre' => 'Gestionar reservas'],
             ['codigo' => 'cotizaciones.gestionar',       'nombre' => 'Gestionar cotizaciones'],
@@ -192,12 +202,15 @@ class RolesAndPermissionsSeeder extends Seeder
                 'sri.establecimientos.ver','sri.establecimientos.crear','sri.establecimientos.editar','sri.establecimientos.eliminar',
                 'sri.estados.ver','sri.callback.recibir',
                 'promociones.ver','promociones.crear','promociones.editar','promociones.eliminar','promociones.activar','promociones.desactivar','promociones.simular','promociones.aplicar','promociones.reglas.crear',
-                'cupones.ver','cupones.crear','cupones.validar','cupones.anular','cupones.generar_masivo','promociones.reportes.ver'
+                'cupones.ver','cupones.crear','cupones.validar','cupones.anular','cupones.generar_masivo','promociones.reportes.ver',
+                'analytics.dashboard.ver','reportes.ventas.ver','reportes.productos.ver','reportes.inventario.ver',
+                'reportes.caja.ver','reportes.cxc.ver','reportes.cxp.ver','reportes.kds.ver','reportes.exportar','analytics.query.ejecutar'
             ],
             'FINANZAS' => [
                 'cxc.ver','cxc.pagar','cxc.anular_pago','cxc.ajustar','cxc.castigar','cxc.planes','cxc.aging','cxc.estado_cuenta','cxc.dunning.ver','cxc.dunning.crear','cxc.dunning.enviar',
                 'cxp.ver','cxp.pagar','cxp.anular_pago','cxp.lotes_pago','cxp.aging','cxp.estado_cuenta',
-                'tesoreria.bancos.ver','tesoreria.bancos.editar','tesoreria.conciliaciones.ver','tesoreria.conciliaciones.match','tesoreria.conciliaciones.cerrar','tesoreria.tarjetas.ver','tesoreria.tarjetas.conciliar'
+                'tesoreria.bancos.ver','tesoreria.bancos.editar','tesoreria.conciliaciones.ver','tesoreria.conciliaciones.match','tesoreria.conciliaciones.cerrar','tesoreria.tarjetas.ver','tesoreria.tarjetas.conciliar',
+                'analytics.dashboard.ver','reportes.ventas.ver','reportes.productos.ver','reportes.inventario.ver','reportes.caja.ver','reportes.cxc.ver','reportes.cxp.ver','reportes.exportar','analytics.query.ejecutar'
             ],
             'BODEGA'      => [
                 'inventario.stock.ver','inventario.movimientos.ver','inventario.ajustes.crear',
@@ -214,13 +227,16 @@ class RolesAndPermissionsSeeder extends Seeder
                 'facturas.enviar_email','facturas.anular',
                 'sri.secuencias.ver','sri.secuencias.next','sri.estados.ver',
                 'promociones.ver','promociones.simular','promociones.aplicar','cupones.validar',
-                'cxc.ver','cxc.pagar','cxc.anular_pago'
+                'cxc.ver','cxc.pagar','cxc.anular_pago',
+                'analytics.dashboard.ver','reportes.ventas.ver','reportes.productos.ver','reportes.inventario.ver',
+                'reportes.caja.ver','reportes.kds.ver','reportes.exportar','analytics.query.ejecutar'
             ],
             'MARKETING'   => [
                 'promociones.ver','promociones.crear','promociones.editar','promociones.eliminar',
                 'promociones.activar','promociones.desactivar','promociones.reglas.crear',
                 'cupones.ver','cupones.crear','cupones.anular','cupones.generar_masivo',
-                'promociones.reportes.ver'
+                'promociones.reportes.ver',
+                'analytics.dashboard.ver','reportes.ventas.ver','reportes.productos.ver','reportes.exportar','analytics.query.ejecutar'
             ],
             'COCINA'      => ['cocina.ver'],
         ];

--- a/routes/api.php
+++ b/routes/api.php
@@ -62,6 +62,9 @@ use App\Http\Controllers\PromocionComboController;
 use App\Http\Controllers\PromocionSimulacionController;
 use App\Http\Controllers\CuponController;
 use App\Http\Controllers\PromocionReporteController;
+use App\Http\Controllers\Reports\DashboardController;
+use App\Http\Controllers\Reports\AnalyticsController;
+use App\Http\Controllers\Reports\ReporteController;
 
 Route::prefix('v1/auth')->group(function () {
     Route::post('/login', [AuthController::class, 'login']);
@@ -315,6 +318,24 @@ Route::prefix('v1')->middleware('auth.jwt')->group(function () {
         Route::post('/tesoreria/conciliaciones/{id}/match', [ConciliacionController::class,'match'])->middleware('can:tesoreria.conciliaciones.match');
         Route::post('/tesoreria/conciliaciones/{id}/cerrar', [ConciliacionController::class,'cerrar'])->middleware('can:tesoreria.conciliaciones.cerrar');
         Route::post('/tesoreria/tarjetas/settlements', [TarjetaSettlementController::class,'store'])->middleware('can:tesoreria.tarjetas.ver');
+
+        // Reportes & Analytics
+        Route::get('/dashboard/resumen', [DashboardController::class, 'resumen'])->middleware('can:analytics.dashboard.ver');
+        Route::get('/analytics/kpis', [AnalyticsController::class, 'kpis'])->middleware('can:analytics.dashboard.ver');
+        Route::get('/reportes/ventas-dia', [ReporteController::class, 'ventasDia'])->middleware('can:reportes.ventas.ver');
+        Route::get('/reportes/ventas', [ReporteController::class, 'ventas'])->middleware('can:reportes.ventas.ver');
+        Route::get('/reportes/productos-mas-vendidos', [ReporteController::class, 'topProductos'])->middleware('can:reportes.productos.ver');
+        Route::get('/reportes/categorias', [ReporteController::class, 'categorias'])->middleware('can:reportes.productos.ver');
+        Route::get('/reportes/inventario-bajo', [ReporteController::class, 'inventarioBajo'])->middleware('can:reportes.inventario.ver');
+        Route::get('/reportes/rotacion', [ReporteController::class, 'rotacion'])->middleware('can:reportes.inventario.ver');
+        Route::get('/reportes/caja', [ReporteController::class, 'caja'])->middleware('can:reportes.caja.ver');
+        Route::get('/reportes/metodos-pago', [ReporteController::class, 'metodosPago'])->middleware('can:reportes.caja.ver');
+        Route::get('/reportes/cxc', [ReporteController::class, 'cxc'])->middleware('can:reportes.cxc.ver');
+        Route::get('/reportes/cxp', [ReporteController::class, 'cxp'])->middleware('can:reportes.cxp.ver');
+        Route::get('/reportes/kds/tiempos', [ReporteController::class, 'kdsTiempos'])->middleware('can:reportes.kds.ver');
+        Route::post('/reportes/export', [ReporteController::class, 'export'])->middleware('can:reportes.exportar');
+        Route::get('/reportes/export/{jobId}', [ReporteController::class, 'exportStatus'])->middleware('can:reportes.exportar');
+        Route::post('/analytics/query', [AnalyticsController::class, 'query'])->middleware('can:analytics.query.ejecutar');
     });
 
     Route::get('/sri/secuencias',[SecuenciaController::class,'index'])->middleware('can:sri.secuencias.ver');

--- a/tests/Feature/ReportesAuthTest.php
+++ b/tests/Feature/ReportesAuthTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Http\Middleware\JwtMiddleware;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ReportesAuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dashboard_requires_auth(): void
+    {
+        $response = $this->getJson('/v1/dashboard/resumen');
+        $response->assertStatus(401);
+    }
+
+    public function test_dashboard_requires_permission(): void
+    {
+        $this->withoutMiddleware(JwtMiddleware::class);
+        $user = User::factory()->create();
+        $this->actingAs($user);
+        $response = $this->getJson('/v1/dashboard/resumen');
+        $response->assertStatus(403);
+    }
+}

--- a/tests/Unit/ReportesServiceTest.php
+++ b/tests/Unit/ReportesServiceTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use App\Services\ReportesService;
+
+class ReportesServiceTest extends TestCase
+{
+    public function test_calcula_kpis_correctamente(): void
+    {
+        $service = new ReportesService();
+        $kpis = $service->calcularKpis(100, 10, 12, 5, 5, 50);
+
+        $this->assertEquals(90.0, $kpis['ventas_netas']);
+        $this->assertEquals(107.0, $kpis['ventas_totales']);
+        $this->assertEquals(21.4, $kpis['ticket_promedio']);
+        $this->assertEquals(40.0, $kpis['margen']);
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold controllers and services for dashboard and report queries
- wire report routes with RBAC permissions and export job skeleton
- document report APIs and register endpoints

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a391a241a0832f841e62f7e402053d