### PR TITLE
feat(clientes): add perfil endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -825,3 +825,33 @@ POST /v1/pedidos/123/items
 | kds.sla.ver | ✓ | ✓ | ✓ | — | — |
 | kds.sla.editar | ✓ | ✓ | ✓ | — | — |
 | kds.stream.ver | ✓ | ✓ | ✓ | — | ✓ |
+
+## Clientes/CRM
+
+### Perfil & RFM
+| Método | Ruta | Descripción | Permiso |
+| ------ | ---- | ----------- | ------- |
+| GET | `/v1/clientes/{id}/perfil` | Obtiene KPIs y score RFM del cliente | `clientes.perfil.ver` |
+
+Ejemplo:
+
+```http
+GET /v1/clientes/123/perfil
+```
+
+Respuesta:
+```json
+{
+  "data": {
+    "kpis": {
+      "total_compras": 520.35,
+      "tickets": 14,
+      "ticket_promedio": 37.17,
+      "ultima_compra": "2025-08-12",
+      "categoria_top": {"id":11},
+      "producto_top": {"id":101}
+    },
+    "rfm": {"recency_dias": 6, "frequency_90d": 5, "monetary_180d": 310.40, "score": "4-5-4"}
+  }
+}
+```

--- a/api_registry.json
+++ b/api_registry.json
@@ -986,4 +986,11 @@
     "module": "notas_credito",
     "permission": "notas_credito.anular"
   }
+  ,{
+    "method": "GET",
+    "path": "/v1/clientes/{id}/perfil",
+    "name": "Perfil de compra",
+    "module": "clientes",
+    "permission": "clientes.perfil.ver"
+  }
 ]

--- a/apis.json
+++ b/apis.json
@@ -359,6 +359,25 @@
           }
         },
         {
+          "name": "GET clientes/{id}/perfil",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{base_url}}/api/v1/clientes/{id}/perfil",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "clientes",
+                "{id}",
+                "perfil"
+              ]
+            }
+          }
+        },
+        {
           "name": "PUT clientes/{id}",
           "request": {
             "method": "PUT",

--- a/app/Http/Controllers/ClientePerfilController.php
+++ b/app/Http/Controllers/ClientePerfilController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Support\Facades\DB;
+
+class ClientePerfilController extends Controller
+{
+    public function show(int $id)
+    {
+        $row = DB::selectOne(
+            "SELECT total_compras, tickets, ticket_promedio, ultima_compra, categoria_top_id, producto_top_id, rfm_json FROM clientes_kpis WHERE cliente_id = :id",
+            ['id' => $id]
+        );
+        if (!$row) {
+            return response()->json([
+                'error' => [
+                    'code' => 'not_found',
+                    'message' => 'Recurso no encontrado'
+                ]
+            ], 404);
+        }
+
+        $kpis = [
+            'total_compras' => (float) $row->total_compras,
+            'tickets' => (int) $row->tickets,
+            'ticket_promedio' => (float) $row->ticket_promedio,
+            'ultima_compra' => $row->ultima_compra,
+            'categoria_top' => $row->categoria_top_id ? ['id' => (int)$row->categoria_top_id] : null,
+            'producto_top' => $row->producto_top_id ? ['id' => (int)$row->producto_top_id] : null,
+        ];
+
+        return [
+            'data' => [
+                'kpis' => $kpis,
+                'rfm' => $row->rfm_json ? json_decode($row->rfm_json, true) : null,
+            ],
+        ];
+    }
+}

--- a/database/migrations/2025_09_18_000007_create_clientes_kpis_table.php
+++ b/database/migrations/2025_09_18_000007_create_clientes_kpis_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('clientes_kpis', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('cliente_id')->unique();
+            $table->decimal('total_compras', 12, 2)->default(0);
+            $table->integer('tickets')->default(0);
+            $table->decimal('ticket_promedio', 12, 2)->default(0);
+            $table->date('ultima_compra')->nullable();
+            $table->unsignedBigInteger('categoria_top_id')->nullable();
+            $table->unsignedBigInteger('producto_top_id')->nullable();
+            $table->json('rfm_json')->nullable();
+            $table->timestamp('updated_at')->useCurrent();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('clientes_kpis');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -18,6 +18,7 @@ use App\Http\Controllers\ImpuestoController;
 use App\Http\Controllers\MetodoPagoController;
 use App\Http\Controllers\CategoriaProductoController;
 use App\Http\Controllers\ClienteController;
+use App\Http\Controllers\ClientePerfilController;
 use App\Http\Controllers\ProveedorController;
 use App\Http\Controllers\ProductoController;
 use App\Http\Controllers\RecetaController;
@@ -201,6 +202,7 @@ Route::prefix('v1')->middleware('auth.jwt')->group(function () {
         Route::get('/clientes', [ClienteController::class, 'index'])->middleware('can:reportes.ver');
         Route::post('/clientes', [ClienteController::class, 'store'])->middleware('can.any:ventas.facturacion,config.usuarios.gestionar');
         Route::get('/clientes/{id}', [ClienteController::class, 'show'])->middleware('can:reportes.ver');
+        Route::get('/clientes/{id}/perfil', [ClientePerfilController::class, 'show'])->middleware('can:clientes.perfil.ver');
         Route::put('/clientes/{id}', [ClienteController::class, 'update'])->middleware('can.any:ventas.facturacion,config.usuarios.gestionar');
         Route::delete('/clientes/{id}', [ClienteController::class, 'destroy'])->middleware('can.any:ventas.facturacion,config.usuarios.gestionar');
 


### PR DESCRIPTION
## Summary
- add KPI storage table and controller for client profile
- expose `/v1/clientes/{id}/perfil` endpoint with RFM metrics
- document clients CRM profile endpoint and register API

## Testing
- `phpunit` *(fails: command not found)*
- `composer test` *(fails: Missing vendor dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a05ccc0c832fb73890b3066d6253