### PR TITLE
Use usuarios table for authentication

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -25,7 +25,7 @@ class AuthController extends Controller
 
             $user = User::where('email', $credentials['email'])->first();
 
-            if (!$user || !Hash::check($credentials['password'], $user->password)) {
+            if (!$user || !Hash::check($credentials['password'], $user->password_hash)) {
                 throw ValidationException::withMessages([
                     'email' => ['The provided credentials are incorrect.'],
                 ]);
@@ -89,13 +89,13 @@ class AuthController extends Controller
             'password' => ['required', 'confirmed'],
         ]);
 
-        if (!Hash::check($data['current_password'], $user->password)) {
+        if (!Hash::check($data['current_password'], $user->password_hash)) {
             throw ValidationException::withMessages([
                 'current_password' => ['Current password is incorrect.'],
             ]);
         }
 
-        $user->password = $data['password'];
+        $user->password_hash = $data['password'];
         $user->save();
         $user->increment('token_version');
 

--- a/app/Http/Requests/StoreCompraRequest.php
+++ b/app/Http/Requests/StoreCompraRequest.php
@@ -16,7 +16,7 @@ class StoreCompraRequest extends ApiFormRequest
             'total' => ['required', 'numeric'],
             'estado' => ['nullable', 'in:borrador,aprobada,anulada'],
             'observacion' => ['nullable', 'string', 'max:255'],
-            'usuario_id' => ['nullable', 'uuid', 'exists:users,id'],
+            'usuario_id' => ['nullable', 'uuid', 'exists:usuarios,id'],
         ];
     }
 }

--- a/app/Http/Requests/UpdateCompraRequest.php
+++ b/app/Http/Requests/UpdateCompraRequest.php
@@ -16,7 +16,7 @@ class UpdateCompraRequest extends ApiFormRequest
             'total' => ['required', 'numeric'],
             'estado' => ['required', 'in:borrador,aprobada,anulada'],
             'observacion' => ['nullable', 'string', 'max:255'],
-            'usuario_id' => ['nullable', 'uuid', 'exists:users,id'],
+            'usuario_id' => ['nullable', 'uuid', 'exists:usuarios,id'],
         ];
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -18,16 +18,26 @@ class User extends Authenticatable
     use HasFactory, Notifiable;
 
     /**
+     * The table associated with the model.
+     */
+    protected $table = 'usuarios';
+
+    /**
      * The attributes that are mass assignable.
      *
      * @var list<string>
      */
     protected $fillable = [
-        'name',
-        'email',
-        'password',
-        'token_version',
+        'empresa_id',
         'local_id',
+        'nombre',
+        'email',
+        'password_hash',
+        'telefono',
+        'activo',
+        'debe_cambiar_password',
+        'ultimo_acceso',
+        'token_version',
     ];
 
     /**
@@ -36,7 +46,7 @@ class User extends Authenticatable
      * @var list<string>
      */
     protected $hidden = [
-        'password',
+        'password_hash',
         'remember_token',
     ];
 
@@ -48,10 +58,18 @@ class User extends Authenticatable
     protected function casts(): array
     {
         return [
-            'email_verified_at' => 'datetime',
-            'password' => 'hashed',
+            'ultimo_acceso' => 'datetime',
+            'password_hash' => 'hashed',
             'token_version' => 'integer',
         ];
+    }
+
+    /**
+     * Get the password for authentication.
+     */
+    public function getAuthPassword()
+    {
+        return $this->password_hash;
     }
 
     public function local(): BelongsTo

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -4,7 +4,6 @@ namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
-use Illuminate\Support\Str;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\User>
@@ -24,21 +23,14 @@ class UserFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->name(),
+            'empresa_id' => 1,
+            'local_id' => null,
+            'nombre' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
-            'email_verified_at' => now(),
-            'password' => static::$password ??= Hash::make('password'),
-            'remember_token' => Str::random(10),
+            'password_hash' => static::$password ??= Hash::make('password'),
+            'activo' => 1,
+            'debe_cambiar_password' => 0,
+            'token_version' => 0,
         ];
-    }
-
-    /**
-     * Indicate that the model's email address should be unverified.
-     */
-    public function unverified(): static
-    {
-        return $this->state(fn (array $attributes) => [
-            'email_verified_at' => null,
-        ]);
     }
 }

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -11,14 +11,21 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('users', function (Blueprint $table) {
+        Schema::create('usuarios', function (Blueprint $table) {
             $table->id();
-            $table->string('name');
+            $table->unsignedBigInteger('empresa_id')->nullable();
+            $table->unsignedBigInteger('local_id')->nullable();
+            $table->string('nombre');
             $table->string('email')->unique();
-            $table->timestamp('email_verified_at')->nullable();
-            $table->string('password');
-            $table->rememberToken();
+            $table->string('password_hash');
+            $table->string('telefono')->nullable();
+            $table->boolean('activo')->default(true);
+            $table->boolean('debe_cambiar_password')->default(false);
+            $table->timestamp('ultimo_acceso')->nullable();
+            $table->unsignedInteger('token_version')->default(0);
+            $table->rememberToken()->nullable();
             $table->timestamps();
+            $table->softDeletes();
         });
 
         Schema::create('password_reset_tokens', function (Blueprint $table) {
@@ -29,7 +36,7 @@ return new class extends Migration
 
         Schema::create('sessions', function (Blueprint $table) {
             $table->string('id')->primary();
-            $table->foreignId('user_id')->nullable()->index();
+            $table->foreignId('usuario_id')->nullable()->index()->constrained('usuarios')->nullOnDelete();
             $table->string('ip_address', 45)->nullable();
             $table->text('user_agent')->nullable();
             $table->longText('payload');
@@ -42,8 +49,8 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('users');
-        Schema::dropIfExists('password_reset_tokens');
         Schema::dropIfExists('sessions');
+        Schema::dropIfExists('password_reset_tokens');
+        Schema::dropIfExists('usuarios');
     }
 };

--- a/database/migrations/2024_01_01_000003_add_token_version_to_users_table.php
+++ b/database/migrations/2024_01_01_000003_add_token_version_to_users_table.php
@@ -8,15 +8,19 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::table('users', function (Blueprint $table) {
-            $table->unsignedInteger('token_version')->default(1)->after('password');
-        });
+        if (Schema::hasTable('usuarios') && !Schema::hasColumn('usuarios', 'token_version')) {
+            Schema::table('usuarios', function (Blueprint $table) {
+                $table->unsignedInteger('token_version')->default(0)->after('password_hash');
+            });
+        }
     }
 
     public function down(): void
     {
-        Schema::table('users', function (Blueprint $table) {
-            $table->dropColumn('token_version');
-        });
+        if (Schema::hasTable('usuarios') && Schema::hasColumn('usuarios', 'token_version')) {
+            Schema::table('usuarios', function (Blueprint $table) {
+                $table->dropColumn('token_version');
+            });
+        }
     }
 };

--- a/database/migrations/2024_01_01_000005_add_local_id_to_users_table.php
+++ b/database/migrations/2024_01_01_000005_add_local_id_to_users_table.php
@@ -8,15 +8,19 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::table('users', function (Blueprint $table) {
-            $table->foreignId('local_id')->nullable()->after('token_version')->constrained('locals')->nullOnDelete();
-        });
+        if (Schema::hasTable('usuarios') && !Schema::hasColumn('usuarios', 'local_id')) {
+            Schema::table('usuarios', function (Blueprint $table) {
+                $table->unsignedBigInteger('local_id')->nullable()->after('token_version');
+            });
+        }
     }
 
     public function down(): void
     {
-        Schema::table('users', function (Blueprint $table) {
-            $table->dropConstrainedForeignId('local_id');
-        });
+        if (Schema::hasTable('usuarios') && Schema::hasColumn('usuarios', 'local_id')) {
+            Schema::table('usuarios', function (Blueprint $table) {
+                $table->dropColumn('local_id');
+            });
+        }
     }
 };

--- a/database/migrations/2024_01_01_000006_create_compras_table.php
+++ b/database/migrations/2024_01_01_000006_create_compras_table.php
@@ -24,7 +24,7 @@ return new class extends Migration
             $table->softDeletes();
 
             $table->foreign('proveedor_id')->references('id')->on('proveedores');
-            $table->foreign('usuario_id')->references('id')->on('users');
+            $table->foreign('usuario_id')->references('id')->on('usuarios');
             $table->unique(['proveedor_id', 'numero_factura']);
         });
     }

--- a/database/migrations/2024_01_01_000009_create_pagos_proveedor_table.php
+++ b/database/migrations/2024_01_01_000009_create_pagos_proveedor_table.php
@@ -19,7 +19,7 @@ return new class extends Migration
             $table->timestamps();
 
             $table->foreign('cxp_id')->references('id')->on('cuentas_por_pagar');
-            $table->foreign('usuario_id')->references('id')->on('users');
+            $table->foreign('usuario_id')->references('id')->on('usuarios');
         });
     }
 


### PR DESCRIPTION
## Summary
- point User model to the `usuarios` table and map new fields
- validate passwords against `password_hash` during login and password changes
- update factory, requests, and migrations to reference `usuarios` instead of `users`

## Testing
- `composer test` *(fails: require(/workspace/vendepro-api/vendor/autoload.php) missing)*
- `composer install` *(fails: GitHub token required for dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a49cb94790832fa49186c26573e474