### PR TITLE
Enable CORS support for API routes

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,6 +3,7 @@
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Http\Middleware\HandleCors;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -12,6 +13,8 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
+        $middleware->appendToGroup('api', HandleCors::class);
+
         $middleware->alias([
             'auth.jwt' => \App\Http\Middleware\JwtMiddleware::class,
             'check.subscription' => \App\Http\Middleware\CheckSubscription::class,

--- a/config/cors.php
+++ b/config/cors.php
@@ -1,0 +1,13 @@
+<?php
+
+return [
+    'paths' => ['api/*', 'v1/*'],
+    'allowed_methods' => ['*'],
+    'allowed_origins' => ['*'],
+    'allowed_origins_patterns' => [],
+    'allowed_headers' => ['*'],
+    'exposed_headers' => [],
+    'max_age' => 0,
+    'supports_credentials' => false,
+];
+


### PR DESCRIPTION
## Summary
- enable CORS middleware for API routes
- add default CORS configuration

## Testing
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed, response 403)*
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68a4a6eec26c832fb19876660c69def3