### PR TITLE
Include local ID in login response

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Puedes importar el archivo `apis.json` en Postman para probar todos los endpoint
 ## Autenticación
 | Método | Ruta | Descripción |
 | ------ | ---- | ----------- |
-| POST | `/v1/auth/login` | Inicia sesión y devuelve un token JWT. |
+| POST | `/v1/auth/login` | Inicia sesión y devuelve un token JWT y el identificador del local. |
 | POST | `/v1/auth/logout` | Cierra la sesión del usuario autenticado. |
 | GET  | `/v1/auth/me` | Obtiene los datos del usuario autenticado. |
 | POST | `/v1/auth/refresh` | Renueva el token JWT. |

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -38,7 +38,10 @@ class AuthController extends Controller
 
             $token = $this->jwt->generate($user);
 
-            return ['token' => $token];
+            return [
+                'token' => $token,
+                'local_id' => $user->local_id,
+            ];
         } catch (ValidationException $e) {
             throw $e;
         } catch (Throwable $e) {

--- a/tests/Feature/AuthLoginTest.php
+++ b/tests/Feature/AuthLoginTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class AuthLoginTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected bool $seed = true;
+
+    public function test_login_returns_token_and_local_id(): void
+    {
+        $response = $this->postJson('/v1/auth/login', [
+            'email' => 'superadmin@vendepro.io',
+            'password' => 'VendePro#2025',
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJsonStructure(['token', 'local_id']);
+
+        $localId = DB::table('usuarios')->where('email', 'superadmin@vendepro.io')->value('local_id');
+        $response->assertJsonPath('local_id', $localId);
+    }
+}

--- a/tests/Feature/RolPermisosTest.php
+++ b/tests/Feature/RolPermisosTest.php
@@ -10,6 +10,8 @@ class RolPermisosTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected bool $seed = true;
+
     private function login(string $email, string $password): string
     {
         $response = $this->postJson('/v1/auth/login', [


### PR DESCRIPTION
## Summary
- return authenticated user's local_id with JWT token
- document login response with local identifier
- add tests for login local_id and seed existing role-permissions tests

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b309285c832fa2562c2565533a96