### PR TITLE
Refactor bodega model to match schema

### DIFF
--- a/app/Http/Controllers/BodegaController.php
+++ b/app/Http/Controllers/BodegaController.php
@@ -17,14 +17,7 @@ class BodegaController extends Controller
         $query = Bodega::query();
 
         if ($q = $request->query('q')) {
-            $query->where(function ($q2) use ($q) {
-                $q2->where('codigo', 'like', "%$q%")
-                    ->orWhere('nombre', 'like', "%$q%");
-            });
-        }
-
-        if ($estado = $request->query('estado')) {
-            $query->where('estado', $estado);
+            $query->where('nombre', 'like', "%$q%");
         }
 
         if ($sort = $request->query('sort')) {
@@ -35,7 +28,7 @@ class BodegaController extends Controller
                     $direction = 'desc';
                     $column = substr($part, 1);
                 }
-                if (in_array($column, ['codigo', 'nombre'])) {
+                if (in_array($column, ['nombre', 'local_id'])) {
                     $query->orderBy($column, $direction);
                 }
             }

--- a/app/Http/Requests/StoreBodegaRequest.php
+++ b/app/Http/Requests/StoreBodegaRequest.php
@@ -14,9 +14,9 @@ class StoreBodegaRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'codigo' => ['required', 'string', 'max:50', 'unique:bodegas,codigo'],
+            'local_id' => ['required', 'integer'],
             'nombre' => ['required', 'string', 'max:255'],
-            'estado' => ['required', 'in:activa,inactiva'],
+            'es_principal' => ['required', 'boolean'],
         ];
     }
 }

--- a/app/Http/Requests/UpdateBodegaRequest.php
+++ b/app/Http/Requests/UpdateBodegaRequest.php
@@ -16,9 +16,9 @@ class UpdateBodegaRequest extends FormRequest
     {
         $id = $this->route('id');
         return [
-            'codigo' => ['required', 'string', 'max:50', Rule::unique('bodegas', 'codigo')->ignore($id)],
+            'local_id' => ['required', 'integer'],
             'nombre' => ['required', 'string', 'max:255'],
-            'estado' => ['required', 'in:activa,inactiva'],
+            'es_principal' => ['required', 'boolean'],
         ];
     }
 }

--- a/app/Http/Resources/BodegaResource.php
+++ b/app/Http/Resources/BodegaResource.php
@@ -12,9 +12,9 @@ class BodegaResource extends JsonResource
     {
         return [
             'id' => $this->id,
-            'codigo' => $this->codigo,
+            'local_id' => $this->local_id,
             'nombre' => $this->nombre,
-            'estado' => $this->estado,
+            'es_principal' => $this->es_principal,
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
         ];

--- a/app/Models/Bodega.php
+++ b/app/Models/Bodega.php
@@ -4,15 +4,14 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Bodega extends Model
 {
-    use HasFactory, SoftDeletes;
+    use HasFactory;
 
     protected $fillable = [
-        'codigo',
+        'local_id',
         'nombre',
-        'estado',
+        'es_principal',
     ];
 }

--- a/database/factories/BodegaFactory.php
+++ b/database/factories/BodegaFactory.php
@@ -13,9 +13,9 @@ class BodegaFactory extends Factory
     public function definition(): array
     {
         return [
-            'codigo' => $this->faker->unique()->regexify('BOD-[0-9]{3}'),
+            'local_id' => 1,
             'nombre' => $this->faker->company(),
-            'estado' => $this->faker->randomElement(['activa','inactiva']),
+            'es_principal' => $this->faker->boolean(),
         ];
     }
 }

--- a/database/migrations/2024_01_01_000006_create_bodegas_table.php
+++ b/database/migrations/2024_01_01_000006_create_bodegas_table.php
@@ -10,11 +10,10 @@ return new class extends Migration
     {
         Schema::create('bodegas', function (Blueprint $table) {
             $table->id();
-            $table->string('codigo')->unique();
+            $table->unsignedBigInteger('local_id');
             $table->string('nombre');
-            $table->enum('estado', ['activa', 'inactiva'])->default('activa');
+            $table->boolean('es_principal')->default(false);
             $table->timestamps();
-            $table->softDeletes();
         });
     }
 

--- a/resources/openapi/bodegas.yaml
+++ b/resources/openapi/bodegas.yaml
@@ -12,11 +12,6 @@ paths:
           schema:
             type: string
         - in: query
-          name: estado
-          schema:
-            type: string
-            enum: [activa, inactiva]
-        - in: query
           name: sort
           schema:
             type: string
@@ -83,21 +78,19 @@ components:
       properties:
         id:
           type: integer
-        codigo:
-          type: string
+        local_id:
+          type: integer
         nombre:
           type: string
-        estado:
-          type: string
-          enum: [activa, inactiva]
+        es_principal:
+          type: boolean
     BodegaInput:
       type: object
-      required: [codigo, nombre, estado]
+      required: [local_id, nombre, es_principal]
       properties:
-        codigo:
-          type: string
+        local_id:
+          type: integer
         nombre:
           type: string
-        estado:
-          type: string
-          enum: [activa, inactiva]
+        es_principal:
+          type: boolean


### PR DESCRIPTION
## Summary
- remove soft deletes and codigo/estado from bodega
- add local reference and principal flag across model, requests, controllers and resources
- update tests and OpenAPI spec for new bodega fields

## Testing
- `composer test` (fails: Failed to open stream: No such file or directory in /workspace/vendepro-api/artisan on line 10)


------
https://chatgpt.com/codex/tasks/task_e_68a4e2a2fb84832f804817dd98dff168