### PR TITLE
Remove unnecessary Throwable import

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -6,7 +6,6 @@ use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Http\Middleware\HandleCors;
 use Illuminate\Validation\ValidationException;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
-use Throwable;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(


### PR DESCRIPTION
## Summary
- remove redundant `Throwable` import causing warnings

## Testing
- `composer install --no-interaction` *(failed: CONNECT tunnel failed, response 403)*
- `composer test` *(failed: vendor/autoload.php not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e6d1bf1c832fb64018ce14ae5ad6