### PR TITLE
feat: add product image URL to API

### DIFF
--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -45,7 +45,7 @@ class MenuController extends Controller
         $callback = function () use ($data, $per, $off, $page, $solo) {
             $sql = "SELECT
   p.id, p.codigo, p.nombre, p.descripcion, p.tipo,
-  p.precio_venta, p.impuesto_id,
+  p.precio_venta, p.impuesto_id, p.url_imagen,
   c.nombre AS categoria_nombre,
   i.codigo AS impuesto_codigo, i.porcentaje AS impuesto_porcentaje,
   COALESCE((

--- a/app/Http/Controllers/ProductoController.php
+++ b/app/Http/Controllers/ProductoController.php
@@ -46,7 +46,7 @@ class ProductoController extends Controller
         $sql = "SELECT
   p.id, p.empresa_id, p.categoria_id, p.codigo, p.nombre, p.descripcion,
   p.tipo, p.sku, p.unidad_id, p.impuesto_id, p.precio_venta, p.costo_promedio,
-  p.es_receta, p.activo, p.created_at, p.updated_at,
+  p.url_imagen, p.es_receta, p.activo, p.created_at, p.updated_at,
   c.nombre AS categoria_nombre,
   um.abreviatura AS unidad,
   i.codigo AS impuesto_codigo, i.porcentaje AS impuesto_porcentaje
@@ -108,6 +108,7 @@ WHERE p.empresa_id = :empresa_id
             'impuesto_id' => ['nullable', 'integer'],
             'precio_venta' => ['numeric', 'min:0'],
             'costo_promedio' => ['numeric', 'min:0'],
+            'url_imagen' => ['nullable', 'string'],
             'es_receta' => ['boolean'],
             'activo' => ['boolean'],
         ]);
@@ -173,10 +174,10 @@ WHERE p.empresa_id = :empresa_id
             DB::insert(
                 "INSERT INTO productos
 (empresa_id, categoria_id, codigo, nombre, descripcion, tipo, sku, unidad_id, impuesto_id,
- precio_venta, costo_promedio, es_receta, activo, created_at, updated_at)
+ precio_venta, costo_promedio, url_imagen, es_receta, activo, created_at, updated_at)
 VALUES
 (:empresa_id, :categoria_id, :codigo, :nombre, :descripcion, :tipo, :sku, :unidad_id, :impuesto_id,
- :precio_venta, :costo_promedio, :es_receta, :activo, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+ :precio_venta, :costo_promedio, :url_imagen, :es_receta, :activo, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
                 [
                     'empresa_id' => $data['empresa_id'],
                     'categoria_id' => $data['categoria_id'] ?? null,
@@ -189,6 +190,7 @@ VALUES
                     'impuesto_id' => $data['impuesto_id'] ?? null,
                     'precio_venta' => $data['precio_venta'] ?? 0,
                     'costo_promedio' => $data['costo_promedio'] ?? 0,
+                    'url_imagen' => $data['url_imagen'] ?? null,
                     'es_receta' => $data['es_receta'] ?? 0,
                     'activo' => $data['activo'] ?? 1,
                 ]
@@ -245,6 +247,7 @@ LIMIT 1",
             'impuesto_id' => ['nullable', 'integer'],
             'precio_venta' => ['numeric', 'min:0'],
             'costo_promedio' => ['numeric', 'min:0'],
+            'url_imagen' => ['nullable', 'string'],
             'es_receta' => ['boolean'],
             'activo' => ['boolean'],
         ]);
@@ -327,6 +330,7 @@ SET categoria_id   = :categoria_id,
     impuesto_id    = :impuesto_id,
     precio_venta   = :precio_venta,
     costo_promedio = :costo_promedio,
+    url_imagen     = :url_imagen,
     es_receta      = :es_receta,
     activo         = :activo,
     updated_at     = CURRENT_TIMESTAMP
@@ -342,6 +346,7 @@ WHERE id = :id AND empresa_id = :empresa_id AND deleted_at IS NULL",
                 'impuesto_id' => $data['impuesto_id'] ?? null,
                 'precio_venta' => $data['precio_venta'] ?? 0,
                 'costo_promedio' => $data['costo_promedio'] ?? 0,
+                'url_imagen' => $data['url_imagen'] ?? null,
                 'es_receta' => $data['es_receta'] ?? 0,
                 'activo' => $data['activo'] ?? 1,
                 'id' => $id,

--- a/app/Http/Controllers/ProductoImportController.php
+++ b/app/Http/Controllers/ProductoImportController.php
@@ -61,6 +61,7 @@ class ProductoImportController extends Controller
             $activo = ($data['activo'] ?? '1') != '0' ? 1 : 0;
             $sku = $data['sku'] ?? null;
             $descripcion = $data['descripcion'] ?? null;
+            $url_imagen = $data['url_imagen'] ?? null;
             $categoria_nombre = $data['categoria_nombre'] ?? null;
             $unidad_abrev = isset($data['unidad_abrev']) ? strtoupper($data['unidad_abrev']) : null;
             $impuesto_codigo = isset($data['impuesto_codigo']) ? strtoupper($data['impuesto_codigo']) : null;
@@ -87,10 +88,10 @@ class ProductoImportController extends Controller
             }
 
             $exists = DB::selectOne("SELECT id FROM productos WHERE empresa_id = :empresa_id AND codigo = :codigo", ['empresa_id'=>$empresa_id,'codigo'=>$codigo]);
-            DB::insert("INSERT INTO productos (empresa_id, categoria_id, codigo, nombre, descripcion, tipo, sku, unidad_id, impuesto_id, precio_venta, costo_promedio, es_receta, activo, created_at, updated_at)
-VALUES (:empresa_id, :categoria_id, :codigo, :nombre, :descripcion, :tipo, :sku, :unidad_id, :impuesto_id, :precio_venta, 0, 0, :activo, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+            DB::insert("INSERT INTO productos (empresa_id, categoria_id, codigo, nombre, descripcion, tipo, sku, unidad_id, impuesto_id, precio_venta, costo_promedio, url_imagen, es_receta, activo, created_at, updated_at)
+VALUES (:empresa_id, :categoria_id, :codigo, :nombre, :descripcion, :tipo, :sku, :unidad_id, :impuesto_id, :precio_venta, 0, :url_imagen, 0, :activo, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
 ON DUPLICATE KEY UPDATE
-  categoria_id=VALUES(categoria_id), nombre=VALUES(nombre), descripcion=VALUES(descripcion), tipo=VALUES(tipo), sku=VALUES(sku), unidad_id=VALUES(unidad_id), impuesto_id=VALUES(impuesto_id), precio_venta=VALUES(precio_venta), costo_promedio=VALUES(costo_promedio), es_receta=VALUES(es_receta), activo=VALUES(activo), updated_at=CURRENT_TIMESTAMP", [
+  categoria_id=VALUES(categoria_id), nombre=VALUES(nombre), descripcion=VALUES(descripcion), tipo=VALUES(tipo), sku=VALUES(sku), unidad_id=VALUES(unidad_id), impuesto_id=VALUES(impuesto_id), precio_venta=VALUES(precio_venta), costo_promedio=VALUES(costo_promedio), url_imagen=VALUES(url_imagen), es_receta=VALUES(es_receta), activo=VALUES(activo), updated_at=CURRENT_TIMESTAMP", [
                 'empresa_id'=>$empresa_id,
                 'categoria_id'=>$categoria_id,
                 'codigo'=>$codigo,
@@ -101,6 +102,7 @@ ON DUPLICATE KEY UPDATE
                 'unidad_id'=>$unidad_id,
                 'impuesto_id'=>$impuesto_id,
                 'precio_venta'=>$precio,
+                'url_imagen'=>$url_imagen,
                 'activo'=>$activo,
             ]);
             if ($exists) {

--- a/app/Http/Controllers/RecetaController.php
+++ b/app/Http/Controllers/RecetaController.php
@@ -33,6 +33,7 @@ class RecetaController extends Controller
         $rows = DB::select(
             "SELECT
   r.insumo_id, p.codigo AS insumo_codigo, p.nombre AS insumo_nombre,
+  p.url_imagen AS insumo_url_imagen,
   r.cantidad, r.merma_porcentaje, p.unidad_id, um.abreviatura AS unidad
 FROM recetas r
 JOIN productos p ON p.id = r.insumo_id
@@ -103,6 +104,7 @@ VALUES (:producto_id, :insumo_id, :cantidad, :merma)",
             $rows = DB::select(
                 "SELECT
   r.insumo_id, p.codigo AS insumo_codigo, p.nombre AS insumo_nombre,
+  p.url_imagen AS insumo_url_imagen,
   r.cantidad, r.merma_porcentaje, p.unidad_id, um.abreviatura AS unidad
 FROM recetas r
 JOIN productos p ON p.id = r.insumo_id
@@ -137,6 +139,7 @@ ORDER BY p.nombre ASC",
         DB::delete("DELETE FROM recetas WHERE producto_id = :producto_id AND insumo_id = :insumo_id", ['producto_id'=>$producto_id,'insumo_id'=>$insumo_id]);
         $rows = DB::select(
             "SELECT r.insumo_id, p.codigo AS insumo_codigo, p.nombre AS insumo_nombre,
+       p.url_imagen AS insumo_url_imagen,
        r.cantidad, r.merma_porcentaje
 FROM recetas r
 JOIN productos p ON p.id = r.insumo_id

--- a/tests/Feature/ProductosSubscriptionTest.php
+++ b/tests/Feature/ProductosSubscriptionTest.php
@@ -37,5 +37,8 @@ class ProductosSubscriptionTest extends TestCase
             ->getJson('/v1/productos?empresa_id=' . $empresaId);
 
         $response->assertStatus(200);
+        $data = $response->json('data');
+        $this->assertIsArray($data);
+        $this->assertArrayHasKey('url_imagen', $data[0]);
     }
 }


### PR DESCRIPTION
## Summary
- expose `url_imagen` for products in listings and detail endpoints
- support image URL in product import and menu/recipe queries
- test that product responses include `url_imagen`

## Testing
- `composer test` *(fails: require(/workspace/vendepro-api/vendor/autoload.php): Failed to open stream: No such file or directory)*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a5194d0bb8832f91ee7c4ac67446d7