### PR TITLE
Allow local-specific category queries

### DIFF
--- a/apis.json
+++ b/apis.json
@@ -218,7 +218,7 @@
           "request": {
             "method": "GET",
             "url": {
-              "raw": "{{base_url}}/api/v1/categorias",
+              "raw": "{{base_url}}/api/v1/categorias?local_id=1",
               "host": [
                 "{{base_url}}"
               ],
@@ -226,6 +226,12 @@
                 "api",
                 "v1",
                 "categorias"
+              ],
+              "query": [
+                {
+                  "key": "local_id",
+                  "value": "1"
+                }
               ]
             }
           }

--- a/app/Http/Controllers/CategoriaProductoController.php
+++ b/app/Http/Controllers/CategoriaProductoController.php
@@ -17,6 +17,22 @@ class CategoriaProductoController extends Controller
         $off = ($page - 1) * $per;
 
         $empresa_id = $request->query('empresa_id');
+        $local_id = $request->query('local_id');
+        if (!$empresa_id && $local_id) {
+            $empresa_id = DB::table('locales')->where('id', $local_id)->value('empresa_id');
+            if (!$empresa_id) {
+                return response()->json([
+                    'error' => 'Validation',
+                    'fields' => ['local_id' => ['Inválido']],
+                ], 422);
+            }
+        }
+        if (!$empresa_id) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => ['empresa_id' => ['Requerido']],
+            ], 422);
+        }
         $padre_id = $request->query('padre_id');
         $q = $request->query('q');
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -181,9 +181,9 @@ Route::prefix('v1')->middleware('auth.jwt')->group(function () {
         Route::put('/metodos-pago/{id}', [MetodoPagoController::class, 'update'])->middleware('can:config.locales.gestionar');
         Route::delete('/metodos-pago/{id}', [MetodoPagoController::class, 'destroy'])->middleware('can:config.locales.gestionar');
 
-        Route::get('/categorias', [CategoriaProductoController::class, 'index'])->middleware('can:productos.crear_editar');
+        Route::get('/categorias', [CategoriaProductoController::class, 'index'])->middleware('can:productos.ver');
         Route::post('/categorias', [CategoriaProductoController::class, 'store'])->middleware('can:productos.crear_editar');
-        Route::get('/categorias/{id}', [CategoriaProductoController::class, 'show'])->middleware('can:productos.crear_editar');
+        Route::get('/categorias/{id}', [CategoriaProductoController::class, 'show'])->middleware('can:productos.ver');
         Route::put('/categorias/{id}', [CategoriaProductoController::class, 'update'])->middleware('can:productos.crear_editar');
         Route::delete('/categorias/{id}', [CategoriaProductoController::class, 'destroy'])->middleware('can:productos.crear_editar');
 


### PR DESCRIPTION
## Summary
- Permit querying categories with a `local_id` that resolves to its company
- Allow read-only category endpoints for users with `productos.ver` permission
- Document `local_id` usage in Postman collection

## Testing
- `php -l app/Http/Controllers/CategoriaProductoController.php`
- `php -l routes/api.php`
- `composer test` *(fails: require(/workspace/vendepro-api/vendor/autoload.php): Failed to open stream)*

------
https://chatgpt.com/codex/tasks/task_e_68a51a702b48832fbbd11dc4de2f65d3