### PR TITLE
Require local_id for mesas listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Nota: se mantiene `GET /v1/estado-suscripcion` para compatibilidad.
 ### Mesas
 | Método | Ruta | Descripción |
 | ------ | ---- | ----------- |
-| GET | `/v1/mesas` | Lista mesas disponibles. Filtrable por `local_id`. |
+| GET | `/v1/mesas` | Lista mesas de un local. Requiere `local_id`. |
 | POST | `/v1/mesas` | Crea una mesa. Requiere `local_id`. |
 | GET | `/v1/mesas/{id}` | Muestra una mesa. |
 | PUT | `/v1/mesas/{id}` | Actualiza una mesa. |

--- a/apis.json
+++ b/apis.json
@@ -904,7 +904,7 @@
           "request": {
             "method": "GET",
             "url": {
-              "raw": "{{base_url}}/api/v1/mesas",
+              "raw": "{{base_url}}/api/v1/mesas?local_id=1",
               "host": [
                 "{{base_url}}"
               ],
@@ -912,6 +912,12 @@
                 "api",
                 "v1",
                 "mesas"
+              ],
+              "query": [
+                {
+                  "key": "local_id",
+                  "value": "1"
+                }
               ]
             }
           }

--- a/app/Http/Controllers/MesaController.php
+++ b/app/Http/Controllers/MesaController.php
@@ -14,11 +14,14 @@ class MesaController extends Controller
 {
     public function index(Request $request)
     {
-        $query = Mesa::query();
-
-        if ($local = $request->query('local_id')) {
-            $query->where('local_id', $local);
+        if (!$local = $request->query('local_id')) {
+            return response()->json([
+                'error' => 'Validation',
+                'fields' => ['local_id' => ['Requerido']],
+            ], 422);
         }
+
+        $query = Mesa::query()->where('local_id', $local);
 
         if ($estado = $request->query('estado')) {
             $query->where('estado', $estado);

--- a/tests/Feature/MesaTest.php
+++ b/tests/Feature/MesaTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Models\Mesa;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -44,5 +45,38 @@ class MesaTest extends TestCase
         ]);
 
         $response->assertStatus(422);
+    }
+
+    public function test_index_requires_local_id(): void
+    {
+        $response = $this->getJson('/v1/mesas');
+        $response->assertStatus(422);
+    }
+
+    public function test_can_list_mesas_by_local_id(): void
+    {
+        Mesa::create([
+            'local_id' => 1,
+            'codigo' => 'M1',
+            'nombre' => 'Mesa 1',
+            'capacidad' => 4,
+            'ubicacion' => 'salon',
+            'estado' => 'activa',
+        ]);
+
+        Mesa::create([
+            'local_id' => 2,
+            'codigo' => 'M2',
+            'nombre' => 'Mesa 2',
+            'capacidad' => 4,
+            'ubicacion' => 'salon',
+            'estado' => 'activa',
+        ]);
+
+        $response = $this->getJson('/v1/mesas?local_id=1');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.local_id', 1);
     }
 }


### PR DESCRIPTION
## Summary
- require `local_id` query parameter for listing mesas
- document and showcase `local_id` requirement in API docs and Postman collection
- add tests for listing mesas by local and validation of `local_id`

## Testing
- `composer install` *(fails: curl error 56... CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a520ef38cc832f88756518e95e3b9e